### PR TITLE
Corrected rounding of gold & silver calculations

### DIFF
--- a/script/helpers.coffee
+++ b/script/helpers.coffee
@@ -269,7 +269,7 @@ module.exports =
   ###
   silver: (num) ->
     if num
-      Math.floor (num - Math.floor(num))*100
+      ("0" + Math.floor (num - Math.floor(num))*100).slice -2
     else
       return "00"
 

--- a/script/helpers.coffee
+++ b/script/helpers.coffee
@@ -260,7 +260,7 @@ module.exports =
   ###
   gold: (num) ->
     if num
-      return (num).toFixed(1).split('.')[0]
+      return Math.floor num
     else
       return "0"
 
@@ -269,7 +269,7 @@ module.exports =
   ###
   silver: (num) ->
     if num
-      (num).toFixed(2).split('.')[1]
+      Math.floor (num - Math.floor(num))*100
     else
       return "00"
 

--- a/tests/algos.mocha.coffee
+++ b/tests/algos.mocha.coffee
@@ -251,4 +251,5 @@ describe 'Helper', ->
   it 'calculates silver coins', ->
     expect(helpers.silver(10)).to.eql 0
     expect(helpers.silver(1.957)).to.eql 95
-    expect(helpers.silver()).to.eql 0
+    expect(helpers.silver(0.01)).to.eql "01"
+    expect(helpers.silver()).to.eql "00"

--- a/tests/algos.mocha.coffee
+++ b/tests/algos.mocha.coffee
@@ -241,3 +241,14 @@ describe 'Cron', ->
       now = moment().startOf('day').add('h', dayStart).add('m', 1)
       console.log {yesterday,now}
       expect(helpers.daysSince(yesterday, {now, dayStart})).to.eql 1
+
+describe 'Helper', ->
+  it 'calculates gold coins', ->
+    expect(helpers.gold(10)).to.eql 10
+    expect(helpers.gold(1.957)).to.eql 1
+    expect(helpers.gold()).to.eql 0
+
+  it 'calculates silver coins', ->
+    expect(helpers.silver(10)).to.eql 0
+    expect(helpers.silver(1.957)).to.eql 95
+    expect(helpers.silver()).to.eql 0


### PR DESCRIPTION
This should fix https://github.com/lefnire/habitrpg/issues/1560.
For example, if I have 1.957 "coins", under the old code that is converted to 2 gold and 96 silver, instead of 1 gold and 95 silver.
