### PR TITLE
Reset lastDrop to zero when day ends

### DIFF
--- a/script/algos.coffee
+++ b/script/algos.coffee
@@ -371,6 +371,11 @@ obj.cron = (user, options={}) ->
 
   user.lastCron = now; paths['lastCron'] = true
 
+  # Reset the lastDrop count to zero
+  if user.items.lastDrop.count > 0
+    user.items.lastDrop.count = 0
+    paths['items.lastDrop'] = true
+
   # User is resting at the inn. Used to be we un-checked each daily without performing calculation (see commits before fb29e35)
   # but to prevent abusing the inn (http://goo.gl/GDb9x) we now do *not* calculate dailies, and simply set lastCron to today
   return if user.flags.rest is true


### PR DESCRIPTION
Discussed in https://github.com/HabitRPG/habitrpg/issues/1625#issuecomment-26829372, it resets the lastDrop's count to zero when day ends.

There are a few thing I'm not sure about this that should be checked before merging:
- user.item.lastDrop.count is always defined? I think so because it's defined in User's schema so it doesn't check for user.items.lastDrop.count to be defined
- `paths['items.lastDrop'] = true` is needed for Mongoose to see what has changed? It's ok to use `paths['items.lastDrop'] = true` even though `items.lastDrop.count` only is modified?
