### PR TITLE
Fix drop ratios

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -8336,7 +8336,7 @@ if(typeof module != 'undefined' && module.exports){
         drop.type = 'Egg';
         drop.dialog = "You've found a " + drop.text + " Egg! " + drop.notes;
       } else {
-        acceptableDrops = rarity < .05 ? ['Golden'] : rarity < .1 ? ['Zombie', 'CottonCandyPink', 'CottonCandyBlue'] : rarity < .15 ? ['Red', 'Shade', 'Skeleton'] : ['Base', 'White', 'Desert'];
+        acceptableDrops = rarity < .05 ? ['Golden'] : rarity < .15 ? ['Zombie', 'CottonCandyPink', 'CottonCandyBlue'] : rarity < .30 ? ['Red', 'Shade', 'Skeleton'] : ['Base', 'White', 'Desert'];
         drop = helpers.randomVal(_.pick(hatchingPotions, (function(v, k) {
           return __indexOf.call(acceptableDrops, k) >= 0;
         })));

--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -8336,7 +8336,7 @@ if(typeof module != 'undefined' && module.exports){
         drop.type = 'Egg';
         drop.dialog = "You've found a " + drop.text + " Egg! " + drop.notes;
       } else {
-        acceptableDrops = rarity < .05 ? ['Golden'] : rarity < .15 ? ['Zombie', 'CottonCandyPink', 'CottonCandyBlue'] : rarity < .30 ? ['Red', 'Shade', 'Skeleton'] : ['Base', 'White', 'Desert'];
+        acceptableDrops = rarity < .02 ? ['Golden'] : rarity < .13 ? ['Zombie', 'CottonCandyPink', 'CottonCandyBlue'] : rarity < .29 ? ['Red', 'Shade', 'Skeleton'] : ['Base', 'White', 'Desert'];
         drop = helpers.randomVal(_.pick(hatchingPotions, (function(v, k) {
           return __indexOf.call(acceptableDrops, k) >= 0;
         })));

--- a/script/algos.coffee
+++ b/script/algos.coffee
@@ -151,13 +151,13 @@ randomDrop = (user, delta, priority, streak = 0, options={}) ->
     # Hatching Potion, 30% chance - break down by rarity.
     else
       acceptableDrops =
-        # Very Rare: 10% (of 30%)
+        # Very Rare: 10% (of 50%)
         if rarity < .05 then ['Golden']
-        # Rare: 20% (of 30%)
-        else if rarity < .1 then ['Zombie', 'CottonCandyPink', 'CottonCandyBlue']
-        # Uncommon: 30% (of 30%)
-        else if rarity < .15 then ['Red', 'Shade', 'Skeleton']
-        # Common: 40% (of 30%)
+        # Rare: 20% (of 50%)
+        else if rarity < .15 then ['Zombie', 'CottonCandyPink', 'CottonCandyBlue']
+        # Uncommon: 30% (of 50%)
+        else if rarity < .30 then ['Red', 'Shade', 'Skeleton']
+        # Common: 40% (of 50%)
         else ['Base', 'White', 'Desert']
 
       # No Rarity (@see https://github.com/HabitRPG/habitrpg/issues/1048, we may want to remove rareness when we add mounts)

--- a/script/algos.coffee
+++ b/script/algos.coffee
@@ -151,13 +151,13 @@ randomDrop = (user, delta, priority, streak = 0, options={}) ->
     # Hatching Potion, 30% chance - break down by rarity.
     else
       acceptableDrops =
-        # Very Rare: 10% (of 50%)
-        if rarity < .05 then ['Golden']
-        # Rare: 20% (of 50%)
-        else if rarity < .15 then ['Zombie', 'CottonCandyPink', 'CottonCandyBlue']
-        # Uncommon: 30% (of 50%)
-        else if rarity < .30 then ['Red', 'Shade', 'Skeleton']
-        # Common: 40% (of 50%)
+        # Very Rare: 4% of 50% (4% each)
+        if rarity < .02 then ['Golden']
+        # Rare: 22% of 50% (7.33% each)
+        else if rarity < .13 then ['Zombie', 'CottonCandyPink', 'CottonCandyBlue']
+        # Uncommon: 32% of 50% (10.66% each)
+        else if rarity < .29 then ['Red', 'Shade', 'Skeleton']
+        # Common: 42% of 50% (14% each)
         else ['Base', 'White', 'Desert']
 
       # No Rarity (@see https://github.com/HabitRPG/habitrpg/issues/1048, we may want to remove rareness when we add mounts)


### PR DESCRIPTION
Ratios left intact as commented in algos.coffee.  

But this means that potion drop odds are as follows:  

Gold:  10% 
CC Pink, CC Blue, Zombie: 6.66% each (6.66 \* 3 = 20% total chance)
Red, Shade, Skeleton:  10% each ( \* 3 = 30%) 
Base, White, Desert:  13.33% each ( \* 3 = 40%)

Suggest (with mixed feelings) reducing Very Rare to 4% and distributing the other 6% between other three tiers.  Will write & submit that patch too; pick your -poison- potion!
