### PR TITLE
Use egg.text instead of egg.name & fix unit tests

### DIFF
--- a/script/algos.coffee
+++ b/script/algos.coffee
@@ -143,8 +143,8 @@ randomDrop = (user, delta, priority, streak = 0, options={}) ->
     # Eggs: 30% chance
     if rarity > .5
       drop = helpers.randomVal eggs
-      user.items.eggs[drop.name] ?= 0
-      user.items.eggs[drop.name]++
+      user.items.eggs[drop.text] ?= 0
+      user.items.eggs[drop.text]++
       drop.type = 'Egg'
       drop.dialog = "You've found a #{drop.text} Egg! #{drop.notes}"
 

--- a/script/algos.coffee
+++ b/script/algos.coffee
@@ -143,8 +143,8 @@ randomDrop = (user, delta, priority, streak = 0, options={}) ->
     # Eggs: 30% chance
     if rarity > .5
       drop = helpers.randomVal eggs
-      user.items.eggs[drop.text] ?= 0
-      user.items.eggs[drop.text]++
+      user.items.eggs[drop.name] ?= 0
+      user.items.eggs[drop.name]++
       drop.type = 'Egg'
       drop.dialog = "You've found a #{drop.text} Egg! #{drop.notes}"
 

--- a/tests/algos.mocha.coffee
+++ b/tests/algos.mocha.coffee
@@ -162,7 +162,7 @@ describe 'User', ->
     it 'gets a bear cub egg', ->
       sinon.stub(Math, 'random', cycle [0, 0.55])
       algos.score(user, user.dailys[0], 'up')
-      expect(user.items.eggs).to.eql {'Bear Cub': 1}
+      expect(user.items.eggs).to.eql {'BearCub': 1}
       expect(user.items.hatchingPotions).to.eql {}
 
     it 'does not get a drop', ->

--- a/tests/algos.mocha.coffee
+++ b/tests/algos.mocha.coffee
@@ -146,26 +146,30 @@ describe 'User', ->
       user = helpers.newUser()
       user.flags.dropsEnabled = true
       # too many Math.random calls to stub, let's return the last element
-      sinon.stub(helpers, 'randomVal', (x)->x[x.length-1])
+      sinon.stub(helpers, 'randomVal', (obj)->
+        result = undefined
+        for key, val of obj
+          result = val
+        result
+      )
 
     it 'gets a golden potion', ->
       sinon.stub(Math, 'random').returns 0
       algos.score(user, user.dailys[0], 'up')
-      expect(user.items.eggs).to.eql undefined
-      expect(user.items.hatchingPotions).to.eql ['Golden']
+      expect(user.items.eggs).to.eql {}
+      expect(user.items.hatchingPotions).to.eql {'Golden': 1}
 
     it 'gets a bear cub egg', ->
-      sinon.stub(Math, 'random', cycle [0, 0.6])
+      sinon.stub(Math, 'random', cycle [0, 0.55])
       algos.score(user, user.dailys[0], 'up')
-      expect(user.items.eggs.length).to.eql 1
-      expect(user.items.eggs[0].name).to.eql 'BearCub'
-      expect(user.items.hatchingPotions).to.eql undefined
+      expect(user.items.eggs).to.eql {'Bear Cub': 1}
+      expect(user.items.hatchingPotions).to.eql {}
 
     it 'does not get a drop', ->
       sinon.stub(Math, 'random').returns 0.5
       algos.score(user, user.dailys[0], 'up')
-      expect(user.items.eggs).to.eql undefined
-      expect(user.items.hatchingPotions).to.eql undefined
+      expect(user.items.eggs).to.eql {}
+      expect(user.items.hatchingPotions).to.eql {}
 
     afterEach ->
       Math.random.restore()


### PR DESCRIPTION
It seems that merging the mounts branch to master broke the build, I've fixed the tests and found that egg.text should be used instead of egg.name in algos.coffee.
