### PR TITLE
Change "HP" to "Health" and clarify Potion type

### DIFF
--- a/script/items.coffee
+++ b/script/items.coffee
@@ -14,35 +14,35 @@ items = module.exports.items =
   ]
   armor: [
     {index: 0, text: "Cloth Armor", classes: 'armor_0', notes:'Training armor.', defense: 0, value:0}
-    {index: 1, text: "Leather Armor", classes: 'armor_1', notes:'Decreases HP loss by 4%.', defense: 4, value:30}
-    {index: 2, text: "Chain Mail", classes: 'armor_2', notes:'Decreases HP loss by 6%.', defense: 6, value:45}
-    {index: 3, text: "Plate Mail", classes: 'armor_3', notes:'Decreases HP loss by 7%.', defense: 7, value:65}
-    {index: 4, text: "Red Armor", classes: 'armor_4', notes:'Decreases HP loss by 8%.', defense: 8, value:90}
-    {index: 5, text: "Golden Armor", classes: 'armor_5', notes:'Decreases HP loss by 10%.', defense: 10, value:120}
-    {index: 6, text: "Shade Armor", classes: 'armor_6', notes:'Decreases HP loss by 12%.', defense: 12, value:150, canOwn: ((u)-> +u.backer?.tier >= 45)}
-    {index: 7, text: "Crystal Armor", classes: 'armor_7', notes:'Decreases HP loss by 14%.', defense: 14, value:170, canOwn: ((u)-> +u.contributor?.level >= 2)}
+    {index: 1, text: "Leather Armor", classes: 'armor_1', notes:'Decreases Health loss by 4%.', defense: 4, value:30}
+    {index: 2, text: "Chain Mail", classes: 'armor_2', notes:'Decreases Health loss by 6%.', defense: 6, value:45}
+    {index: 3, text: "Plate Mail", classes: 'armor_3', notes:'Decreases Health loss by 7%.', defense: 7, value:65}
+    {index: 4, text: "Red Armor", classes: 'armor_4', notes:'Decreases Health loss by 8%.', defense: 8, value:90}
+    {index: 5, text: "Golden Armor", classes: 'armor_5', notes:'Decreases Health loss by 10%.', defense: 10, value:120}
+    {index: 6, text: "Shade Armor", classes: 'armor_6', notes:'Decreases Health loss by 12%.', defense: 12, value:150, canOwn: ((u)-> +u.backer?.tier >= 45)}
+    {index: 7, text: "Crystal Armor", classes: 'armor_7', notes:'Decreases Health loss by 14%.', defense: 14, value:170, canOwn: ((u)-> +u.contributor?.level >= 2)}
   ]
   head: [
     {index: 0, text: "No Helm", classes: 'head_0', notes:'Training helm.', defense: 0, value:0}
-    {index: 1, text: "Leather Helm", classes: 'head_1', notes:'Decreases HP loss by 2%.', defense: 2, value:15}
-    {index: 2, text: "Chain Coif", classes: 'head_2', notes:'Decreases HP loss by 3%.', defense: 3, value:25}
-    {index: 3, text: "Plate Helm", classes: 'head_3', notes:'Decreases HP loss by 4%.', defense: 4, value:45}
-    {index: 4, text: "Red Helm", classes: 'head_4', notes:'Decreases HP loss by 5%.', defense: 5, value:60}
-    {index: 5, text: "Golden Helm", classes: 'head_5', notes:'Decreases HP loss by 6%.', defense: 6, value:80}
-    {index: 6, text: "Shade Helm", classes: 'head_6', notes:'Decreases HP loss by 7%.', defense: 7, value:100, canOwn: ((u)-> +u.backer?.tier >= 45)}
-    {index: 7, text: "Crystal Helm", classes: 'head_7', notes:'Decreases HP loss by 8%.', defense: 8, value:120, canOwn: ((u)-> +u.contributor?.level >= 3)}
+    {index: 1, text: "Leather Helm", classes: 'head_1', notes:'Decreases Health loss by 2%.', defense: 2, value:15}
+    {index: 2, text: "Chain Coif", classes: 'head_2', notes:'Decreases Health loss by 3%.', defense: 3, value:25}
+    {index: 3, text: "Plate Helm", classes: 'head_3', notes:'Decreases Health loss by 4%.', defense: 4, value:45}
+    {index: 4, text: "Red Helm", classes: 'head_4', notes:'Decreases Health loss by 5%.', defense: 5, value:60}
+    {index: 5, text: "Golden Helm", classes: 'head_5', notes:'Decreases Health loss by 6%.', defense: 6, value:80}
+    {index: 6, text: "Shade Helm", classes: 'head_6', notes:'Decreases Health loss by 7%.', defense: 7, value:100, canOwn: ((u)-> +u.backer?.tier >= 45)}
+    {index: 7, text: "Crystal Helm", classes: 'head_7', notes:'Decreases Health loss by 8%.', defense: 8, value:120, canOwn: ((u)-> +u.contributor?.level >= 3)}
   ]
   shield: [
     {index: 0, text: "No Shield", classes: 'shield_0', notes:'No Shield.', defense: 0, value:0}
-    {index: 1, text: "Wooden Shield", classes: 'shield_1', notes:'Decreases HP loss by 3%', defense: 3, value:20}
-    {index: 2, text: "Buckler", classes: 'shield_2', notes:'Decreases HP loss by 4%.', defense: 4, value:35}
-    {index: 3, text: "Reinforced Shield", classes: 'shield_3', notes:'Decreases HP loss by 5%.', defense: 5, value:55}
-    {index: 4, text: "Red Shield", classes: 'shield_4', notes:'Decreases HP loss by 7%.', defense: 7, value:70}
-    {index: 5, text: "Golden Shield", classes: 'shield_5', notes:'Decreases HP loss by 8%.', defense: 8, value:90}
-    {index: 6, text: "Tormented Skull", classes: 'shield_6', notes:'Decreases HP loss by 9%.', defense: 9, value:120, canOwn: ((u)-> +u.backer?.tier >= 45)}
-    {index: 7, text: "Crystal Shield", classes: 'shield_7', notes:'Decreases HP loss by 10%.', defense: 10, value:150, canOwn: ((u)-> +u.contributor?.level >= 5)}
+    {index: 1, text: "Wooden Shield", classes: 'shield_1', notes:'Decreases Health loss by 3%', defense: 3, value:20}
+    {index: 2, text: "Buckler", classes: 'shield_2', notes:'Decreases Health loss by 4%.', defense: 4, value:35}
+    {index: 3, text: "Reinforced Shield", classes: 'shield_3', notes:'Decreases Health loss by 5%.', defense: 5, value:55}
+    {index: 4, text: "Red Shield", classes: 'shield_4', notes:'Decreases Health loss by 7%.', defense: 7, value:70}
+    {index: 5, text: "Golden Shield", classes: 'shield_5', notes:'Decreases Health loss by 8%.', defense: 8, value:90}
+    {index: 6, text: "Tormented Skull", classes: 'shield_6', notes:'Decreases Health loss by 9%.', defense: 9, value:120, canOwn: ((u)-> +u.backer?.tier >= 45)}
+    {index: 7, text: "Crystal Shield", classes: 'shield_7', notes:'Decreases Health loss by 10%.', defense: 10, value:150, canOwn: ((u)-> +u.contributor?.level >= 5)}
   ]
-  potion: {type: 'potion', text: "Potion", notes: "Recover 15 HP (Instant Use)", value: 25, classes: 'potion'}
+  potion: {type: 'potion', text: "Health Potion", notes: "Recover 15 Health (Instant Use)", value: 25, classes: 'potion'}
   reroll: {type: 'reroll', text: "Re-Roll", classes: 'reroll', notes: "Resets your task values back to 0 (yellow). Useful when everything's red and it's hard to stay alive.", value:0 }
 
   eggs:
@@ -73,7 +73,7 @@ items = module.exports.items =
   food:
     Meat:             text: 'Meat', target: 'Base'
     Milk:             text: 'Milk', target: 'White'
-    Potatoe:          text: 'Potatoe', target: 'Desert'
+    Potatoe:          text: 'Potato', target: 'Desert'
     Strawberry:       text: 'Strawberry', target: 'Red'
     Chocolate:        text: 'Chocolate', target: 'Shade'
     Fish:             text: 'Fish', target: 'Skeleton'
@@ -108,7 +108,7 @@ _.each items.hatchingPotions, (pot,k) ->
   _.defaults pot, {name: k, value: 2, notes: "Pour this on an egg, and it will hatch as a #{pot.text} pet."}
 
 _.each items.food, (food,k) ->
-  _.defaults food, {value: 1, name: k, notes: "Feed this to a pet and it may grown into a sturdy steed."}
+  _.defaults food, {value: 1, name: k, notes: "Feed this to a pet and it may grow into a sturdy steed."}
 
 module.exports.buyItem = (user, type) ->
   nextItem =


### PR DESCRIPTION
Continuing standardization of terminology, using "Health" wherever possible instead of "HP".

Also retitled the "Potion" in the basic item shop to be "Health Potion", to distinguish from Hatching Potions, and fixed a couple of mount system typos I spotted along the way.
