### PR TITLE
Content update to match habitrpg/#2019 fix

### DIFF
--- a/script/content.coffee
+++ b/script/content.coffee
@@ -437,10 +437,10 @@ _.each api.hatchingPotions, (pot,k) ->
 api.food =
   Meat:             text: 'Meat', target: 'Base'
   Milk:             text: 'Milk', target: 'White'
-  Potatoe:          text: 'Potato', target: 'Desert'
-  Strawberry:       text: 'Strawberry', target: 'Red'
+  Potatoe:          text: 'a Potato', target: 'Desert'
+  Strawberry:       text: 'a Strawberry', target: 'Red'
   Chocolate:        text: 'Chocolate', target: 'Shade'
-  Fish:             text: 'Fish', target: 'Skeleton'
+  Fish:             text: 'a Fish', target: 'Skeleton'
   RottenMeat:       text: 'Rotten Meat', target: 'Zombie'
   CottonCandyPink:  text: 'Pink Cotton Candy', target: 'CottonCandyPink'
   CottonCandyBlue:  text: 'Blue Cotton Candy', target: 'CottonCandyBlue'

--- a/script/content.coffee
+++ b/script/content.coffee
@@ -437,10 +437,10 @@ _.each api.hatchingPotions, (pot,k) ->
 api.food =
   Meat:             text: 'Meat', target: 'Base'
   Milk:             text: 'Milk', target: 'White'
-  Potatoe:          text: 'a Potato', target: 'Desert'
-  Strawberry:       text: 'a Strawberry', target: 'Red'
+  Potatoe:          text: 'Potato', target: 'Desert', article: 'a'
+  Strawberry:       text: 'Strawberry', target: 'Red', article: 'a'
   Chocolate:        text: 'Chocolate', target: 'Shade'
-  Fish:             text: 'a Fish', target: 'Skeleton'
+  Fish:             text: 'Fish', target: 'Skeleton', article: 'a'
   RottenMeat:       text: 'Rotten Meat', target: 'Zombie'
   CottonCandyPink:  text: 'Pink Cotton Candy', target: 'CottonCandyPink'
   CottonCandyBlue:  text: 'Blue Cotton Candy', target: 'CottonCandyBlue'

--- a/script/content.coffee
+++ b/script/content.coffee
@@ -50,9 +50,9 @@ gear =
       1: text: "Acolyte Rod", notes:'Crafted during a healer\'s initiation. Increases INT by 2.', int: 2, value:20
       2: text: "Quartz Rod", notes:'Topped with a gem bearing curative properties. Increases INT by 3.', int: 3, value:30
       3: text: "Amethyst Rod", notes:'Purifies poison at a touch. Increases INT by 5.', int: 5, value:45
-      4: text: "Priest Rod", notes:'As much a badge of office as a healing tool. Increases INT by 7.', int:7, value:65
-      5: text: "Royal Crosier", notes:'Shines with the pure light of blessings. Increases INT by 9.', int: 9, value:90
-      6: text: "Golden Crosier", notes:'Soothes the pain of all who look upon it. Increases INT by 11.', int: 11, value:120, last: true
+      4: text: "Physician Rod", notes:'As much a badge of office as a healing tool. Increases INT by 7.', int:7, value:65
+      5: text: "Royal Scepter", notes:'Fit to grace the hand of a monarch, or of one who stands at a monarch\'s right hand. Increases INT by 9.', int: 9, value:90
+      6: text: "Golden Scepter", notes:'Soothes the pain of all who look upon it. Increases INT by 11.', int: 11, value:120, last: true
     special:
       0: text: "Dark Souls Blade", notes:'Feasts upon foes\' life essence to power its wicked strokes. Increases STR by 20.', str: 20, value:150, canOwn: ((u)-> +u.backer?.tier >= 70)
       1: text: "Crystal Blade", notes:'Its glittering facets tell the tale of a hero. Increases all attributes by 6.', str: 6, per: 6, con: 6, int: 6, value:170, canOwn: ((u)-> +u.contributor?.level >= 4)
@@ -87,9 +87,9 @@ gear =
       #0: text: "Novice Robe", notes:'For healers in training. Confers no benefit.', value:0
       1: text: "Acolyte Robe", notes:'Garment showing humility and purpose. Increases CON by 6.', con: 6, value:30
       2: text: "Medic Robe", notes:'Worn by those dedicated to tending the wounded in battle. Increases CON by 9.', con: 9, value:45
-      3: text: "Defender Vestment", notes:'Turns the healer\'s own magics inward to fend off harm. Increases CON by 12.', con: 12, value:65
-      4: text: "Priest Vestment", notes:'Projects authority and dissipates curses. Increases CON by 15.', con: 15, value:90
-      5: text: "Royal Vestment", notes:'Attire of those who have saved the lives of kings. Increases CON by 18.', con: 18, value:120, last: true
+      3: text: "Defender Mantle", notes:'Turns the healer\'s own magics inward to fend off harm. Increases CON by 12.', con: 12, value:65
+      4: text: "Physician Mantle", notes:'Projects authority and dissipates curses. Increases CON by 15.', con: 15, value:90
+      5: text: "Royal Mantle", notes:'Attire of those who have saved the lives of kings. Increases CON by 18.', con: 18, value:120, last: true
     special:
       0: text: "Shade Armor",   notes:'Screams when struck, for it feels pain in its wearer\'s place. Increases CON by 20.', con: 20, value:150, canOwn: ((u)-> +u.backer?.tier >= 45)
       1: text: "Crystal Armor", notes:'Its tireless power inures the wearer to mundane discomfort. Increases all attributes by 6.', con: 6, str: 6, per: 6, int: 6, value:170, canOwn: ((u)-> +u.contributor?.level >= 2)
@@ -155,7 +155,7 @@ gear =
       #0: text: "No Shield", notes:'No shield.', def: 0, value:0
       1: text: "Medic Buckler", notes:'Easy to disengage, freeing a hand for bandaging. Increases CON by 2.', con: 2, value:20
       2: text: "Kite Shield", notes:'Tapered shield with the symbol of healing. Increases CON by 4.', con: 4, value:35
-      3: text: "Hospitaler Shield", notes:'Traditional shield of defender knights. Increases CON by 6.', con: 6, value:50
+      3: text: "Protector Shield", notes:'Traditional shield of defender knights. Increases CON by 6.', con: 6, value:50
       4: text: "Savior Shield", notes:'Stops blows aimed at nearby innocents as well as those aimed at you. Increases CON by 9.', con: 9, value:70
       5: text: "Royal Shield", notes:'Bestowed upon those most dedicated to the kingdom\'s defense. Increases CON by 12.', con: 12, value:90, last: true
     special:

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -879,7 +879,7 @@ api.wrap = (user) ->
           user.items.food[drop.name] ?= 0
           user.items.food[drop.name]+= 1
           drop.type = 'Food'
-          drop.dialog = "You've found #{drop.text}! #{drop.notes}"
+          drop.dialog = "You've found #{drop.article} #{drop.text}! #{drop.notes}"
 
           # Eggs: 30% chance
         else if rarity > .3

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -610,7 +610,7 @@ api.wrap = (user) ->
           user.preferences.disableClasses = false
           user.autoAllocate = false
         else
-          return cb({code:401,message:"Not enough gems"}) unless user.balance >= .75
+          return cb({code:401,message:"Not enough Gems."}) unless user.balance >= .75
           user.balance -= .75
         _.merge user.stats, {str: 0, con: 0, per: 0, int: 0, points: user.stats.lvl}
         user.flags.classSelected = false
@@ -653,7 +653,7 @@ api.wrap = (user) ->
 
       # If they're trying to purhcase a too-expensive reward, don't allow them to do that.
       if task.value > stats.gp and task.type is 'reward'
-        return cb('Not enough Gold');
+        return cb('Not enough Gold!');
 
       delta = 0
 
@@ -879,7 +879,7 @@ api.wrap = (user) ->
           user.items.food[drop.name] ?= 0
           user.items.food[drop.name]+= 1
           drop.type = 'Food'
-          drop.dialog = "You've found a #{drop.text} Food! #{drop.notes}"
+          drop.dialog = "You've found #{drop.text}! #{drop.notes}"
 
           # Eggs: 30% chance
         else if rarity > .3


### PR DESCRIPTION
Removing remaining religious references from Healer equipment. "Mantle" instead of "Vestment", "Scepter" instead of "Crosier", "Physician" instead of "Priest", "Protector" instead of "Hospitaler".
