### PR TITLE
Fix preening bug: null values

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -95,7 +95,7 @@ preenHistory = (history) ->
       newHistory.push
         date: moment(group[0].date).toDate()
         #date: moment(group[0].date).format('MM/DD/YYYY') # Use this one when testing
-        value: _.reduce(group, ((m, obj) -> m + api.value), 0) / group.length # average
+        value: _.reduce(group, ((m, obj) -> m + obj.value), 0) / group.length # average
       true
 
   # Keep the last:


### PR DESCRIPTION
There was a bug in the preening user history code: it was storing null values. Sadly, that means that there are loss of historical data.
@lefnire, with this change merged, all the tests are going to pass :)
