### PR TITLE
Add Critical Hit notificaiton via user._tmp

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -761,6 +761,8 @@ api.wrap = (user) ->
       addPoints = ->
         # ===== CRITICAL HITS =====
         _crit = user.fns.crit()
+        # if there was a crit, alert the user via notification
+        user._tmp.crit = _crit if _crit > 1
 
         # Exp Modifier
         # ===== Intelligence =====


### PR DESCRIPTION
Adds the critical ht bonus amount to user._tmp.crit so that the client can notify the user if they get a crit.

Fixes HabitRPG/habitrpg#2029.
