### PR TITLE
Tasks get blue when you do them often, and the text for Pickpocket should reflect this

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -10147,7 +10147,7 @@ var global=self;/**
         mana: 10,
         lvl: 11,
         target: 'task',
-        notes: "Your nimble fingers run through the task's pockets and find some treasures for yourself. You gain an increased gold bonus on the task, higher yet the 'fatter' (greener) your task.",
+        notes: "Your nimble fingers run through the task's pockets and find some treasures for yourself. You gain an increased gold bonus on the task, higher yet the 'fatter' (bluer) your task.",
         cast: function(user, target) {
           return user.stats.gp += (target.value < 0 ? 1 : target.value + 1) + user._statsComputed.per * .075;
         }


### PR DESCRIPTION
I believe the sequence is red -> yellow -> green -> blue.  The text for 'Pickpocket' now reflects this slightly better, I believe.
