### PR TITLE
fix(?) for issue 2222 - untick removes too little XP,GP

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -743,7 +743,7 @@ api.wrap = (user) ->
             if direction is 'down' and task.type is 'daily' and options.cron
               nextDelta *= (1 - _.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),0) / task.checklist.length)
             # If To-Do, point-match the TD per checklist item
-            if direction is 'up' and task.type is 'todo'
+            if task.type is 'todo'
               nextDelta *= task.checklist.length
 
           unless task.type is 'reward'


### PR DESCRIPTION
This is a proposed fix for issue 2222 ("unticking a todo with a checklist removes much less XP and GP than it should") BUT I HAVE NOT TESTED THIS (I don't have a local install yet - sorry). Please see my comments at the end of that issue. Note that I don't know why "if direction is 'up'" was originally included - there might have been (and still be) a good reason for it.
