### PR TITLE
Add some value to high Mana pools

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -63,7 +63,7 @@ process.chdir = function (dir) {
 };
 
 },{}],3:[function(require,module,exports){
-var global=self;/**
+var global=typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {};/**
  * @license
  * Lo-Dash 2.4.1 (Custom Build) <http://lodash.com/>
  * Build: `lodash modern -o ./dist/lodash.js`
@@ -11738,7 +11738,7 @@ var process=require("__browserify_process");(function() {
         return typeof cb === "function" ? cb(null, _.pick(user, $w('stats'))) : void 0;
       },
       score: function(req, cb) {
-        var addPoints, calculateDelta, delta, direction, id, num, options, stats, subtractPoints, task, th, _ref, _ref1;
+        var addPoints, calculateDelta, delta, direction, id, num, options, stats, subtractPoints, task, th, _ref, _ref1, _ref2;
         _ref = req.params, id = _ref.id, direction = _ref.direction;
         task = user.tasks[id];
         options = req.query || {};
@@ -11866,7 +11866,7 @@ var process=require("__browserify_process");(function() {
             } else {
               calculateDelta();
               addPoints();
-              user.stats.mp += 1 + (((_ref1 = task.checklist) != null ? _ref1.length : void 0) || 0);
+              user.stats.mp += _.max([1 + (((_ref1 = task.checklist) != null ? _ref1.length : void 0) || 0), .01 * user._statsComputed.maxMP * (1 + (((_ref2 = task.checklist) != null ? _ref2.length : void 0) || 0))]);
               if (user.stats.mp >= user._statsComputed.maxMP) {
                 user.stats.mp = user._statsComputed.maxMP;
               }
@@ -12190,7 +12190,7 @@ var process=require("__browserify_process");(function() {
         if (user.items.lastDrop.count > 0) {
           user.items.lastDrop.count = 0;
         }
-        user.stats.mp += 10;
+        user.stats.mp += _.max([10, .1 * user._statsComputed.maxMP]);
         if (user.stats.mp > user._statsComputed.maxMP) {
           user.stats.mp = user._statsComputed.maxMP;
         }

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -834,7 +834,7 @@ api.wrap = (user) ->
           else
             calculateDelta()
             addPoints() # obviously for delta>0, but also a trick to undo accidental checkboxes
-            user.stats.mp += (1 + (task.checklist?.length or 0)) # MP++ per ToDo, bonus per CLI
+            user.stats.mp += _.max([(1 + (task.checklist?.length or 0)), (.01 * user._statsComputed.maxMP * (1 + (task.checklist?.length or 0)))]) # MP++ per ToDo, bonus per CLI
             user.stats.mp = user._statsComputed.maxMP if user.stats.mp >= user._statsComputed.maxMP
 
         when 'reward'
@@ -1119,7 +1119,7 @@ api.wrap = (user) ->
       if user.items.lastDrop.count > 0
         user.items.lastDrop.count = 0
 
-      user.stats.mp += 10
+      user.stats.mp += _.max([10,.1 * user._statsComputed.maxMP])
       user.stats.mp = user._statsComputed.maxMP if user.stats.mp > user._statsComputed.maxMP
 
       # User is resting at the inn. Used to be we un-checked each daily without performing calculation (see commits before fb29e35)


### PR DESCRIPTION
Improved fix to [this HabitRPG issue](https://github.com/HabitRPG/habitrpg/issues/2069). Day rollover now gives the better of 10 MP or 10% of max MP. Mana drip from To-Dos gives the better of 1 MP \* (task + checklist items) or 1% of max MP \* (task + checklist items).

Gives some actual utility to high Mana pools--bank space tends not to be much of a concern unless the user is away for some time.
