### PR TITLE
Rebirth fixes: deequip pets and mounts, allow stacking at max level

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -63,7 +63,7 @@ process.chdir = function (dir) {
 };
 
 },{}],3:[function(require,module,exports){
-var global=self;/**
+var global=typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {};/**
  * @license
  * Lo-Dash 2.4.1 (Custom Build) <http://lodash.com/>
  * Build: `lodash modern -o ./dist/lodash.js`
@@ -11321,6 +11321,22 @@ var process=require("__browserify_process");(function() {
           gear[type].head = 'head_base_0';
           return gear[type].shield = 'shield_base_0';
         });
+        if (user.items.currentPet) {
+          user.ops.equip({
+            params: {
+              type: 'pet',
+              key: user.items.currentPet
+            }
+          });
+        }
+        if (user.items.currentMount) {
+          user.ops.equip({
+            params: {
+              type: 'mount',
+              key: user.items.currentMount
+            }
+          });
+        }
         gear.owned = {
           weapon_warrior_0: true
         };
@@ -11337,7 +11353,7 @@ var process=require("__browserify_process");(function() {
         if (!user.achievements.rebirths) {
           user.achievements.rebirths = 1;
           user.achievements.rebirthLevel = lvl;
-        } else if (lvl > user.achievements.rebirthLevel) {
+        } else if (lvl > user.achievements.rebirthLevel || (lvl = 100)) {
           user.achievements.rebirths++;
           user.achievements.rebirthLevel = lvl;
         }

--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -11353,7 +11353,7 @@ var process=require("__browserify_process");(function() {
         if (!user.achievements.rebirths) {
           user.achievements.rebirths = 1;
           user.achievements.rebirthLevel = lvl;
-        } else if (lvl > user.achievements.rebirthLevel || (lvl = 100)) {
+        } else if (lvl > user.achievements.rebirthLevel || lvl === 100) {
           user.achievements.rebirths++;
           user.achievements.rebirthLevel = lvl;
         }

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -435,6 +435,8 @@ api.wrap = (user) ->
         gear[type].weapon = 'weapon_warrior_0'
         gear[type].head   = 'head_base_0'
         gear[type].shield = 'shield_base_0'
+      if user.items.currentPet then user.ops.equip({params:{type: 'pet', key: user.items.currentPet}})
+      if user.items.currentMount then user.ops.equip({params:{type: 'mount', key: user.items.currentMount}})
       # Strip owned gear down to the training sword
       gear.owned = {weapon_warrior_0:true}
       user.markModified? 'items.gear.owned'
@@ -449,7 +451,7 @@ api.wrap = (user) ->
       if not (user.achievements.rebirths)
         user.achievements.rebirths = 1
         user.achievements.rebirthLevel = lvl
-      else if (lvl > user.achievements.rebirthLevel)
+      else if (lvl > user.achievements.rebirthLevel or lvl = 100)
         user.achievements.rebirths++
         user.achievements.rebirthLevel = lvl
       cb? null, user

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -451,7 +451,7 @@ api.wrap = (user) ->
       if not (user.achievements.rebirths)
         user.achievements.rebirths = 1
         user.achievements.rebirthLevel = lvl
-      else if (lvl > user.achievements.rebirthLevel or lvl = 100)
+      else if (lvl > user.achievements.rebirthLevel or lvl is 100)
         user.achievements.rebirths++
         user.achievements.rebirthLevel = lvl
       cb? null, user


### PR DESCRIPTION
Two tweaks to Rebirth behavior:
- Undergoing a Rebirth deequips the user's current pet and mount, if any.
- In the unlikely, hardest-core event that a player reaches level 100 more than once, they can stack Rebirths there as many times as they make it. (Previously they needed to exceed their prior level to re-earn the achievement, making it impossible to stack the Rebirth achievement after being reborn from lvl 100.)
