### PR TITLE
subtract MP when unticking a todo (instead of add)

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -834,8 +834,11 @@ api.wrap = (user) ->
           else
             calculateDelta()
             addPoints() # obviously for delta>0, but also a trick to undo accidental checkboxes
-            user.stats.mp += _.max([(1 + (task.checklist?.length or 0)), (.01 * user._statsComputed.maxMP * (1 + (task.checklist?.length or 0)))]) # MP++ per ToDo, bonus per CLI
+            mpDelta = _.max([(1 + (task.checklist?.length or 0)), (.01 * user._statsComputed.maxMP * (1 + (task.checklist?.length or 0)))]) # MP++ per ToDo, bonus per CLI
+            mpDelta *= -1 if direction is 'down'  # unticking a todo
+            user.stats.mp += mpDelta
             user.stats.mp = user._statsComputed.maxMP if user.stats.mp >= user._statsComputed.maxMP
+            user.stats.mp = 0 if user.stats.mp < 0   # BUT DO WE WANT THIS? SEE COMMIT DESCRIPTION
 
         when 'reward'
         # Don't adjust values for rewards


### PR DESCRIPTION
Currently, when you untick a completed todo, you GAIN MP. Lines 837-839 of this change will cause you to loose it instead.

Line 841 will prevent your MP becoming negative if you used up all your MP before unticking the todo... BUT do we want to prevent negative MP under that circumstance? Perhaps it should be allowed to go negative? The circumstance I'm thinking of is:
1. You tick off a todo, causing your MP to reach (for example) 10.
2. You cast a spell that costs 10 MP. MP is now 0.
3. You realise that you had ticked off the todo accidentally (or deliberately to rort the system!) and so you untick the todo, which (without line 841) would cause your MP to go to -1. Strictly speaking, it SHOULD be -1 because you had spent MP that you hadn't truly earned, but negative MP might look weird and cause "bug" reports. Line 841 will prevent it being negative.
