### PR TITLE
Server side of Rebirth-related fix: don't remove Wolf Eggs upon drops unlock

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -63,7 +63,7 @@ process.chdir = function (dir) {
 };
 
 },{}],3:[function(require,module,exports){
-var global=self;/**
+var global=typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {};/**
  * @license
  * Lo-Dash 2.4.1 (Custom Build) <http://lodash.com/>
  * Build: `lodash modern -o ./dist/lodash.js`
@@ -12344,7 +12344,11 @@ var process=require("__browserify_process");(function() {
         }
         if (!user.flags.dropsEnabled && user.stats.lvl >= 4) {
           user.flags.dropsEnabled = true;
-          user.items.eggs["Wolf"] = 1;
+          if (user.items.eggs["Wolf"] > 0) {
+            user.items.eggs["Wolf"]++;
+          } else {
+            user.items.eggs["Wolf"] = 1;
+          }
         }
         if (!user.flags.classSelected && user.stats.lvl >= 10) {
           user.flags.classSelected;

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1086,7 +1086,7 @@ api.wrap = (user) ->
         user.flags.partyEnabled = true
       if !user.flags.dropsEnabled and user.stats.lvl >= 4
         user.flags.dropsEnabled = true
-        user.items.eggs["Wolf"] = 1
+        if user.items.eggs["Wolf"] > 0 then user.items.eggs["Wolf"]++ else user.items.eggs["Wolf"] = 1
       if !user.flags.classSelected and user.stats.lvl >= 10
         user.flags.classSelected
       if !user.flags.rebirthEnabled and (user.stats.lvl >= 50 or user.achievements.ultimateGear or user.achievements.beastMaster)


### PR DESCRIPTION
Previously, if user had >1 Wolf Egg, performed a Rebirth, then unlocked drops again, they would be reset to 1 Wolf Egg. Now Habit checks to see if they have some Wolf Eggs already, and if so, gives them one instead of setting the quantity to one.

Question for @lefnire / @paglias: I'm being careful about not performing a `++` on an undefined quantity. Is that the right code practice, or will JS turn an undefined into a 1 if the type is number and I add to it?
