### PR TITLE
Custom Day Start: change condition on when we run cron

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -31,7 +31,10 @@ api.startOfWeek = api.startOfWeek = (options={}) ->
 
 api.startOfDay = (options={}) ->
   o = sanitizeOptions(options)
-  moment(o.now).startOf('day').add('h', o.dayStart)
+  dayStart = moment(o.now).startOf('day').add('h', o.dayStart)
+  # if between midnight and Custom Day Start, jump back to previous day
+  dayStart.subtract('day', 1) if moment(o.now).isBefore(dayStart)
+  return dayStart
 
 dayMapping = {0:'su',1:'m',2:'t',3:'w',4:'th',5:'f',6:'s'}
 
@@ -1239,4 +1242,3 @@ api.wrap = (user, main=true) ->
     get: ->
       tasks = user.habits.concat(user.dailys).concat(user.todos).concat(user.rewards)
       _.object(_.pluck(tasks, "id"), tasks)
-

--- a/tests/algos.mocha.coffee
+++ b/tests/algos.mocha.coffee
@@ -487,6 +487,8 @@ describe 'Helper', ->
     expect(shared.startOfDay({now: new Date(2013, 0, 1, 0)}).format('YYYY-MM-DD HH:mm')).to.eql '2013-01-01 00:00'
     expect(shared.startOfDay({now: new Date(2013, 0, 1, 5)}).format('YYYY-MM-DD HH:mm')).to.eql '2013-01-01 00:00'
     expect(shared.startOfDay({now: new Date(2013, 0, 1, 23, 59, 59)}).format('YYYY-MM-DD HH:mm')).to.eql '2013-01-01 00:00'
+    # between midnight and custom day start
+    expect(shared.startOfDay({now: new Date(2013, 0, 2, 2), dayStart: 4}).format('YYYY-MM-DD HH:mm')).to.eql '2013-01-01 04:00'
 
   it 'counts pets', ->
     pets = {}

--- a/tests/algos.mocha.coffee
+++ b/tests/algos.mocha.coffee
@@ -46,7 +46,7 @@ rewrapUser = (user)->
 expectStrings = (obj, paths) ->
   _.each paths, (path) -> expect(obj[path]).to.be.ok()
 
-# options.daysAgo: days ago when the last cron was executed
+# options.hoursAgo: hours since the last cron was executed
 beforeAfter = (options={}) ->
   user = newUser()
   [before, after] = [user, _.cloneDeep(user)]
@@ -57,9 +57,9 @@ beforeAfter = (options={}) ->
   if options.limitOne
     before["#{options.limitOne}s"] = [before["#{options.limitOne}s"][0]]
     after["#{options.limitOne}s"] = [after["#{options.limitOne}s"][0]]
-  lastCron = +(moment(options.now || +new Date).subtract('days', options.daysAgo)) if options.daysAgo
+  lastCron = +(moment(options.now || +new Date).subtract('hours', options.hoursAgo)) unless options.hoursAgo == undefined
   _.each [before,after], (obj) ->
-    obj.lastCron = lastCron if options.daysAgo
+    obj.lastCron = lastCron unless options.hoursAgo == undefined
   {before:before, after:after}
 #TODO calculate actual poins
 
@@ -287,7 +287,7 @@ describe 'Cron', ->
 #    expect(paths.lastCron).to.be true # busted cron (was set to after today's date)
 
   it 'only dailies & todos are effected', ->
-    {before,after} = beforeAfter({daysAgo:1})
+    {before,after} = beforeAfter({hoursAgo:24})
     before.dailys = before.todos = after.dailys = after.todos = []
     after.fns.cron()
     expect(after.lastCron).to.not.be before.lastCron # make sure cron was run
@@ -304,7 +304,7 @@ describe 'Cron', ->
       @clock.restore()
 
     it 'should preen user history', ->
-      {before,after} = beforeAfter({daysAgo:1})
+      {before,after} = beforeAfter({hoursAgo:24})
       history = [
         # Last year should be condensed to one entry, avg: 1
         {date:'09/01/2012', value: 0}
@@ -362,7 +362,7 @@ describe 'Cron', ->
 
   describe 'Todos', ->
     it '1 day missed', ->
-      {before,after} = beforeAfter({daysAgo:1})
+      {before,after} = beforeAfter({hoursAgo:24})
       before.dailys = after.dailys = []
       after.fns.cron()
 
@@ -388,7 +388,7 @@ describe 'Cron', ->
       runCron = (options) ->
         _.each [480, 240, 0, -120], (timezoneOffset) -> # test different timezones
           now = shared.startOfWeek({timezoneOffset}).add('hours', options.currentHour||0)
-          {before,after} = beforeAfter({now, timezoneOffset, daysAgo:1, dayStart:options.dayStart||0, limitOne:'daily'})
+          {before,after} = beforeAfter({now, timezoneOffset, hoursAgo:options.hoursAgo||0, dayStart:options.dayStart||0, limitOne:'daily'})
           before.dailys[0].repeat = after.dailys[0].repeat = options.repeat if options.repeat
           before.dailys[0].streak = after.dailys[0].streak = 10
           before.dailys[0].completed = after.dailys[0].completed = true if options.checked
@@ -405,7 +405,7 @@ describe 'Cron', ->
         steps:
 
           'due yesterday':
-            defaults: {daysAgo:1, limitOne: 'daily'}
+            defaults: {hoursAgo:24, limitOne: 'daily'}
             steps:
 
               '(simple)': {expect:'losePoints'}
@@ -415,7 +415,7 @@ describe 'Cron', ->
                 defaults: {repeat:{su:1,m:true,t:1,w:1,th:1,f:1,s:1}}
                 steps:
                   'pre-dayStart':
-                    defaults: {currentHour:3, dayStart:4, shouldDo:true}
+                    defaults: {hoursAgo:2,currentHour:3, dayStart:4, shouldDo:true}
                     steps:
                       'checked': {checked: true, expect:'noChange'}
                       'un-checked': {checked: false, expect:'noChange'}
@@ -429,7 +429,7 @@ describe 'Cron', ->
                 defaults: {repeat:{su:1,m:false,t:1,w:1,th:1,f:1,s:1}}
                 steps:
                   'pre-dayStart':
-                    defaults: {currentHour:3, dayStart:4, shouldDo:true}
+                    defaults: {hoursAgo:23, currentHour:3, dayStart:4, shouldDo:true}
                     steps:
                       'checked': {checked: true, expect:'noChange'}
                       'un-checked': {checked: false, expect:'noChange'}
@@ -442,18 +442,18 @@ describe 'Cron', ->
           'not due yesterday':
             defaults: repeatWithoutLastWeekday()
             steps:
-              '(simple)': {expect:'noDamage'}
-              'post-dayStart': {currentHour:5,dayStart:4, expect:'noDamage'}
-              'pre-dayStart': {currentHour:3, dayStart:4, expect:'noChange'}
+              '(simple)': {hoursAgo:24, expect:'noDamage'}
+              'post-dayStart': {hoursAgo:23,currentHour:5,dayStart:4, expect:'noDamage'}
+              'pre-dayStart': {hoursAgo:21, currentHour:3, dayStart:4, expect:'noChange'}
 
       recurseCronMatrix = (obj, options={}) ->
         if obj.steps
           _.each obj.steps, (step, text) ->
             o = _.cloneDeep options
             o.text ?= ''; o.text += " #{text} "
-            recurseCronMatrix step, _.defaults(o,obj.defaults)
+            recurseCronMatrix step, _.assign(o, obj.defaults)
         else
-          it "#{options.text}", -> runCron(_.defaults(obj,options))
+          it "#{options.text}", -> runCron(_.assign(options, obj))
       recurseCronMatrix(cronMatrix)
 
     it 'calculates day differences with dayStart properly', ->


### PR DESCRIPTION
This is an attempt to fix some of the problems people have with custom
day start, especially those in habitrpg/habitrpg#1057.

I believe this is a bug in when we decide to run cron. Right now we look
for the difference between `startOfDay(user.lastCron)` and `now` to be
greater than 0. I'll explain why this is a problem.

For the following cases, let today be January 8th and yesterday be January 7th.

Consider the scenario where `dayStart = 0` and `user.lastCron` is sometime yesterday.

`lastCron.start('days').add('d', dayStart)` will just be January 7th at midnight. Then
the difference will be greater than 0 anytime after midnight on January
8th. Works as expected.

However, consider the case where `dayStart` is set to something greater than
0, like 3. Now let's say the user logs on after midnight on January 8th
but before their Custom Day Start (something common in many reports),
and cron is run.

`lasCron.start('days').add('d', dayStart)` will be January 8th at
3am. Therefore the difference won't be greater than 0 until January 9th
at 3am and their dailies, etc won't become unchecked.

Therefore, this commit adds two extra conditions to check when `daysMissed`
is equal to zero:
- cronBeforeStart: Was the last cron run before the Custom Day Start
  time for today's date?
- nowAfterStart: Have we passed the Current Day Start time for today's
  date?

I believe that both of these condition must be true OR daysMissed must
be greater than zero to run cron. Please, please, please double and
triple check my logic here. I don't want to make this any more of a
mess, because working with times makes my brain hurt.

(cc @lefnire)
