### PR TITLE
Rebirth fix: flip owned items to explicit false 

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -11511,9 +11511,13 @@ var process=require("__browserify_process");(function() {
               }
             });
           }
-          gear.owned = {
-            weapon_warrior_0: true
-          };
+          _.each(gear.owned, function(v, k) {
+            if (gear.owned[k]) {
+              gear.owned[k] = false;
+              return true;
+            }
+          });
+          gear.owned.weapon_warrior_0 = true;
           if (typeof user.markModified === "function") {
             user.markModified('items.gear.owned');
           }

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -441,8 +441,9 @@ api.wrap = (user, main=true) ->
           gear[type].shield = 'shield_base_0'
         if user.items.currentPet then user.ops.equip({params:{type: 'pet', key: user.items.currentPet}})
         if user.items.currentMount then user.ops.equip({params:{type: 'mount', key: user.items.currentMount}})
-        # Strip owned gear down to the training sword
-        gear.owned = {weapon_warrior_0:true}
+        # Strip owned gear down to the training sword, but preserve purchase history so user can re-purchase limited edition equipment
+        _.each gear.owned, (v, k) -> if gear.owned[k] then gear.owned[k] = false; true
+        gear.owned.weapon_warrior_0 = true
         user.markModified? 'items.gear.owned'
         user.preferences.costume = false
         # Remove unlocked features


### PR DESCRIPTION
Per current handling of `canOwn`, gear items set to an explicit `false` can be rebought after loss. This commit makes the Rebirth op handle owned gear this way, so a Reborn character doesn't unfairly lose access to limited edition equipment.
