### PR TITLE
fix(perfect-day): do not count non-active dailies when calculating perfect-day

### DIFF
--- a/tests/algos.mocha.coffee
+++ b/tests/algos.mocha.coffee
@@ -159,6 +159,14 @@ describe 'User', ->
     expect(user.stats.buffs.str).to.be 1
     expect(user.achievements.perfect).to.be 1
 
+    # Handle greyed-out dailys
+    yesterday = moment().subtract('days',1);
+    user.dailys[0].repeat[shared.dayMapping[yesterday.day()]] = 0
+    _.each user.dailys[1..], (d)->d.completed = true
+    cron()
+    expect(user.stats.buffs.str).to.be 1
+    expect(user.achievements.perfect).to.be 2
+
 
   describe 'Death', ->
     user = undefined


### PR DESCRIPTION
When we calculate the perfect-day achievement, we should check to see if
the daily had repeat set for yesterday as well as if it was completed.

Fixes HabitRPG/habitrpg#2446
