### PR TITLE
stop wasting Stealth on todos and completed dailies

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1151,9 +1151,11 @@ api.wrap = (user, main=true) ->
       user.todos.concat(user.dailys).forEach (task) ->
         return unless task
 
-        return if user.stats.buffs.stealth && user.stats.buffs.stealth-- # User "evades" a certain number of tasks
-
         {id, type, completed, repeat} = task
+
+        return if (type is 'daily') && !completed && user.stats.buffs.stealth && user.stats.buffs.stealth-- # User "evades" a certain number of uncompleted dailies
+        
+        
         # Deduct experience for missed Daily tasks, but not for Todos (just increase todo's value)
         unless completed
           scheduleMisses = daysMissed


### PR DESCRIPTION
If I understand the code correctly, the stealth buff was being decremented regardless of task type and completion status. This change causes stealth to be used up only for dailies that have not been completed.
