### PR TITLE
not a perfect day if all dailies were grey dailies

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1158,7 +1158,7 @@ api.wrap = (user, main=true) ->
         
         # Count number of Daily tasks actually actioned by the user, not just "completed" (greyed-out) because it's a day when they are not active (note: this does NOT count grey-dailies that were actioned anyway).
         # ASSUME a Daily was completed yesterday (i.e., not before yesterday if the user hasn't logged on for a while)
-        actionedDailyTally++ if (type is 'daily') && completed && api.shouldDo(dateLastActioned, task.repeat, {dayStart}))
+        actionedDailyTally++ if (type is 'daily') && completed && api.shouldDo(dateLastActioned, task.repeat, {dayStart})
         
         # Deduct experience for missed Daily tasks, but not for Todos (just increase todo's value)
         unless completed


### PR DESCRIPTION
Currently, if all your dailies are greyed out because none are set to be actioned that day, then you get a "perfect day" achievement (because you didn't miss any dailies). This seems like cheating. :)

This fix - hopefully - counts up the number of dailies actually actioned (i.e., it counts a daily if that daily was completed and if it was set so that it needed to be completed on the day that the user last logged in). A perfect day happens only if the count is greater than zero.

"dateLastActioned" is supposed to be yesterday if the user last logged in yesterday, or the day before if they last logged in on the day before, etc. It might benefit from a better name but I can't think of one.

THIS NEEDS TO BE TESTED! I can't test because I still don't have my local install working because I am lame. :( Feel free to not give me any credit if this "fix" requires additional work from other people! Or, of course, if it's just plain wrong. :)
