### PR TITLE
fix(calculateDelta): don't detrain stats on ripening To-Dos

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -12046,7 +12046,7 @@ var process=require("__browserify_process");(function() {
                 }
               }
               if (task.type !== 'reward') {
-                if (user.preferences.automaticAllocation === true && user.preferences.allocationMode === 'taskbased') {
+                if (user.preferences.automaticAllocation === true && user.preferences.allocationMode === 'taskbased' && !(task.type === 'todo' && direction === 'down')) {
                   user.stats.training[task.attribute] += nextDelta;
                 }
                 adjustAmt = nextDelta;

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -760,7 +760,7 @@ api.wrap = (user, main=true) ->
                 nextDelta *= task.checklist.length
 
             unless task.type is 'reward'
-              if (user.preferences.automaticAllocation is true and user.preferences.allocationMode is 'taskbased') then user.stats.training[task.attribute] += nextDelta
+              if (user.preferences.automaticAllocation is true and user.preferences.allocationMode is 'taskbased' and !(task.type is 'todo' and direction is 'down')) then user.stats.training[task.attribute] += nextDelta
               adjustAmt = nextDelta
               # ===== STRENGTH =====
               # (Only for up-scoring, ignore up-onlies and rewards)


### PR DESCRIPTION
Previously, on cron, the reddening of To-Dos would subtract from the stat training for task-based auto-allocation. This had a tendency to cause users with lots of active tasks to get backward stat allocations on levelup. Now the "down" direction for To-Dos is not counted for attribute training. (Missed Dailies will still detrain.)

Fixes https://github.com/HabitRPG/habitrpg/issues/2247
