### PR TITLE
fix(checklists): Make checklist To-Do behavior more intuitive

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -12041,8 +12041,10 @@ var process=require("__browserify_process");(function() {
                     return m + (i.completed ? 1 : 0);
                   }), 0) / task.checklist.length;
                 }
-                if (task.type === 'todo') {
-                  nextDelta *= task.checklist.length;
+                if (task.type === 'todo' && direction === 'up') {
+                  nextDelta *= 1 + _.reduce(task.checklist, (function(m, i) {
+                    return m + (i.completed ? 1 : 0);
+                  }), 0);
                 }
               }
               if (task.type !== 'reward') {

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -755,9 +755,9 @@ api.wrap = (user, main=true) ->
               # If the Daily, only dock them them a portion based on their checklist completion
               if direction is 'down' and task.type is 'daily' and options.cron
                 nextDelta *= (1 - _.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),0) / task.checklist.length)
-              # If To-Do, point-match the TD per checklist item
-              if task.type is 'todo'
-                nextDelta *= task.checklist.length
+              # If To-Do, point-match the TD per checklist item completed
+              if task.type is 'todo' and direction is 'up'
+                nextDelta *= (1 + _.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),0))
 
             unless task.type is 'reward'
               if (user.preferences.automaticAllocation is true and user.preferences.allocationMode is 'taskbased') then user.stats.training[task.attribute] += nextDelta


### PR DESCRIPTION
Previously, all To-Do scoring was multiplied by the length of the checklist, including cron "reddening" and ultimate scoring. The checkboxes themselves only affected MP bonuses. Now, checklist tasks redden at the same rate as any other task, and the score multiplier only applies to checklist items that have actually been accomplished when the user concludes the overall To-Do.

Fixes HabitRPG/habitrpg#2327, HabitRPG/habitrpg#2405, and HabitRPG/habitrpg#2483.
