### PR TITLE
Added FAQ and Tutorials links, linking the Vimeo Tutorial and Wiki FAQ

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -80,6 +80,8 @@
   "options": " Options",
   "logout": " Log Out",
   "sync": " Sync",
+  "FAQ" : " FAQ",
+  "Tutorials" : " Tutorials",
   "psst": "Psst",
 
 "_commentnotifcations" : "NOTIFICATIONS",


### PR DESCRIPTION
Added in links to the user menu to link users to the Video Tutorials and FAQ. Translations are stored in the habitrpg-shared repository, under a pull request with the same name.

Fixes: https://github.com/HabitRPG/habitrpg/issues/2472
Relates To: https://github.com/HabitRPG/habitrpg/pull/2488
