### PR TITLE
Disallow feeding mounts/Copy Strings

### DIFF
--- a/script/content.coffee
+++ b/script/content.coffee
@@ -155,7 +155,8 @@ gear =
 
   shield:
     base:
-      0: text: "No Shield", notes:'No shield.', value:0
+      0: text: "No Off-Hand Equipment", notes:'No shield or second weapon.', value:0
+      //changed because this is what shows up for all classes, including those without shields
     warrior:
       #0: text: "No Shield", notes:'No shield.', value:0
       1: text: "Wooden Shield", notes:'Round shield of thick wood. Increases CON by 2.', con: 2, value:20


### PR DESCRIPTION
Ach, sorry, I didn't mean to put these on the same branch.

The latest commits contain the newest strings needed for the copy.

The older commits disallow feeding of mounts you own.
