### PR TITLE
fix(checklists): Bring MP behavior in sync with XP/Gold

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -12261,7 +12261,7 @@ var process=require("__browserify_process");(function() {
           return typeof cb === "function" ? cb(null, _.pick(user, $w('stats'))) : void 0;
         },
         score: function(req, cb) {
-          var addPoints, calculateDelta, delta, direction, id, mpDelta, multiplier, num, options, stats, subtractPoints, task, th, _ref, _ref1, _ref2, _ref3;
+          var addPoints, calculateDelta, delta, direction, id, mpDelta, multiplier, num, options, stats, subtractPoints, task, th, _ref, _ref1, _ref2;
 
           _ref = req.params, id = _ref.id, direction = _ref.direction;
           task = user.tasks[id];
@@ -12399,7 +12399,11 @@ var process=require("__browserify_process");(function() {
                 task.dateCompleted = direction === 'up' ? new Date : void 0;
                 calculateDelta();
                 addPoints();
-                multiplier = ((_ref3 = task.checklist) != null ? _ref3.length : void 0) || 1;
+                multiplier = _.max([
+                  _.reduce(task.checklist, (function(m, i) {
+                    return m + (i.completed ? 1 : 0);
+                  }), 1), 1
+                ]);
                 mpDelta = _.max([multiplier, .01 * user._statsComputed.maxMP * multiplier]);
                 if (direction === 'down') {
                   mpDelta *= -1;

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -861,7 +861,7 @@ api.wrap = (user, main=true) ->
               calculateDelta()
               addPoints() # obviously for delta>0, but also a trick to undo accidental checkboxes
               # MP++ per checklist item in ToDo, bonus per CLI
-              multiplier = task.checklist?.length || 1
+              multiplier = _.max([(_.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),1)),1])
               mpDelta = _.max([(multiplier), (.01 * user._statsComputed.maxMP * multiplier)])
               mpDelta *= -1 if direction is 'down'  # unticking a todo
               user.stats.mp += mpDelta


### PR DESCRIPTION
Previously, the player would accrue Mana for every checklist item when a To-Do was completed, regardless of whether or not those checklist items were complete. This was inconsistent with XP and Gold, which were only multiplied based on the number of checklist items previously clicked. Now Mana acts the same way, multiplying MP scored by (1 + completed checklist items).

I'm not certain the `_.max` wrapper is necessary/the best way to do this. I just know that attempting to use `task.checklist?` in there _didn't_ work, always returning 1.
