### PR TITLE
Changed some skills to use a hyperbolic formula

### DIFF
--- a/script/content.coffee
+++ b/script/content.coffee
@@ -325,7 +325,7 @@ api.spells =
       target: 'task'
       notes: "You savagely hit a single task with all of your might, beating it into submission. The task's redness decreases."
       cast: (user, target) ->
-        target.value += user._statsComputed.str * .01 * user.fns.crit('per')
+        target.value += 2.5 * (user._statsComputed.str / (user._statsComputed.str + 50))
         user.party.quest.progress.up += Math.ceil(user._statsComputed.str * .2) if user.party.quest.key
     defensiveStance:
       text: 'Defensive Stance'
@@ -365,7 +365,8 @@ api.spells =
       target: 'task'
       notes: "Your nimble fingers run through the task's pockets and find some treasures for yourself. You gain an increased gold bonus on the task, higher yet the 'fatter' (bluer) your task."
       cast: (user, target) ->
-        user.stats.gp += (if target.value < 0 then 1 else target.value+1) + user._statsComputed.per * .075
+        bonus = (if target.value < 0 then 1 else target.value+2) * user._statsComputed.per
+        user.stats.gp += 75 * (bonus / (bonus + 800))
     backStab:
       text: 'Backstab'
       mana: 15
@@ -419,7 +420,7 @@ api.spells =
       cast: (user, target) ->
         _.each user.tasks, (target) ->
           return if target.type is 'reward'
-          target.value += user._statsComputed.int * .006
+          target.value += 1.5 * (user._statsComputed.int / (user._statsComputed.int + 40))
     protectAura:
       text: 'Protective Aura'
       mana: 30

--- a/script/content.coffee
+++ b/script/content.coffee
@@ -325,7 +325,7 @@ api.spells =
       target: 'task'
       notes: "You savagely hit a single task with all of your might, beating it into submission. The task's redness decreases."
       cast: (user, target) ->
-        target.value += 2.5 * (user._statsComputed.str / (user._statsComputed.str + 50))
+        target.value += 2.5 * (user._statsComputed.str / (user._statsComputed.str + 50)) * user.fns.crit('per')
         user.party.quest.progress.up += Math.ceil(user._statsComputed.str * .2) if user.party.quest.key
     defensiveStance:
       text: 'Defensive Stance'

--- a/script/content.coffee
+++ b/script/content.coffee
@@ -365,8 +365,8 @@ api.spells =
       target: 'task'
       notes: "Your nimble fingers run through the task's pockets and find some treasures for yourself. You gain an increased gold bonus on the task, higher yet the 'fatter' (bluer) your task."
       cast: (user, target) ->
-        bonus = (if target.value < 0 then 1 else target.value+2) * user._statsComputed.per
-        user.stats.gp += 75 * (bonus / (bonus + 800))
+        bonus = (if target.value < 0 then 1 else target.value+2) + (user._statsComputed.per * 0.5)
+        user.stats.gp += 25 * (bonus / (bonus + 75))
     backStab:
       text: 'Backstab'
       mana: 15


### PR DESCRIPTION
There have been problems with the formulas for Pickpocket #2093, Brutal Smash #2469, and Searing Brightness #2081.  I modified these formulas based on Aubec's excel sheet on the [Trello card](https://trello.com/c/L1H6LiZ3/110-character-stats-attributes-the-class-system).

Pickpocket is using his formula exactly with the assumption that task values < 0 should still be counted as 1.  This should make sure that the skill never gives you an obscene amount of gold.  I set the max to 75, but that can easily be changed.

For Brutal Smash and Searing Brightness I used values that would make the formula return a similar value as the linear formula using a stat of 200.  These skills have had problems with not showing any changes even after multiple casts.  This formula should make the tasks more effective at lower levels and taper off on higher levels.

Brutal Smashes max effectiveness raises the task value by 2.5 while Searing Brightness raises the value by 1.5.  That seems appropriate given that Searing Brightness affects all tasks, while Brutal Smash affects only 1 and can also crit.
