### PR TITLE
prevent critical hit when unticking a task

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -806,7 +806,8 @@ api.wrap = (user, main=true) ->
 
         addPoints = ->
           # ===== CRITICAL HITS =====
-          _crit = user.fns.crit()
+          # allow critical hit only when checking off a task, not when unchecking it:
+          _crit = (if delta > 0 then user.fns.crit() else 1)
           # if there was a crit, alert the user via notification
           user._tmp.crit = _crit if _crit > 1
 


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/2356

Currently, when you untick a todo or daily, there's a chance of a critical hit. This prevents that.
