### PR TITLE
Fix #730: id property ignored when updating task

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -505,7 +505,7 @@ api.wrap = (user, main=true) ->
 
       updateTask: (req, cb) ->
         return cb?({code:404,message:"Task not found"}) unless task = user.tasks[req.params?.id]
-        _.merge task, _.omit(req.body,'checklist')
+        _.merge task, _.omit(req.body,['checklist','id'])
         task.checklist = req.body.checklist if req.body.checklist
         task.markModified? 'tags'
         cb? null, task


### PR DESCRIPTION
When calling the user.updateTask function if there was an id in the body it would override the id from the request URI.
