### PR TITLE
Tour - To-Dos: change "deadline" to "date"

### DIFF
--- a/locales/en/npc.json
+++ b/locales/en/npc.json
@@ -39,7 +39,7 @@
     "typeGoalsText": "HabitRPG allows you to track your goals in three different ways. These goals are categorized in columns as Habits, Dailies, or To-Dos.",
     "tourHabits": "Habits are goals that you constantly track. They can be given plus or minus values, allowing you to gain experience and gold for good habits or lose health for bad ones.",
     "tourDailies": "Dailies are goals that you want to complete once a day. Checking off a daily reaps experience and gold. Failing to check off your daily before the day resets results in a loss of health. You can change your day start settings from the options menu.",
-    "tourTodos": "To-Dos are one-off goals that you can get to eventually. While it is possible to set a deadline on a to-do, they are not required. To-Dos make for a quick and easy way to gain experience.",
+    "tourTodos": "To-Dos are one-off goals that you can get to eventually. While it is possible to set a date on a to-do, they are not required. To-Dos make for a quick and easy way to gain experience.",
     "tourRewards": "All that gold you earned will allow you to reward yourself with either custom or in-game prizes. Buy them liberally – rewarding yourself is integral in forming good habits.",
     "hoverOver": "Hover over comments",
     "hoverOverText": "You can add comments to your tasks by clicking the edit icon. Hover over each task's comment for more details about how HabitRPG works. When you're ready to get started, you can delete the existing tasks and add your own.",


### PR DESCRIPTION
"Deadline" (or even "due date") implies that something happens when the date is reached. "Date" implies that to a lesser degree. We get questions in the Tavern and Newbies Guild about the effect of dates on to-dos, so maybe this is a change worth making. Yeah, I know it's picky. Feel free to ignore if you prefer.
