### PR TITLE
fix incorrect text for Light Crystals, fix Plain Egg pluralisation, remove excess word

### DIFF
--- a/locales/en/questsContent.json
+++ b/locales/en/questsContent.json
@@ -32,7 +32,7 @@
 
   "questRatText": "The Rat King",
   "questRatNotes": "Garbage! Massive piles of unchecked dailies are lying all across Habitica. The problem has become so serious that hordes of rats are now seen everywhere. You notice @Pandah petting one of the beasts lovingly. She explains that rats are gentle creatures that feed on unchecked dailies. The real problem is that the dailies have fallen into the sewer, creating a dangerous pit that must be cleared. As you descend into the sewers, a massive rat, with blood red eyes and mangled yellow teeth, attacks you, defending its horde. Will you cower in fear or face the fabled Rat King?",
-  "questRatCompletion": "Your final strike saps the gargantuan rat's strength, his eyes fading to a dull grey. The beast splits into many tiny rats, which scurry off in fright. You notice @Pandah standing behind you, looking at the once mighty creature. She explains that the citizens of Habitica have been inspiried by your courage and are quickly completing all their unchecked dailies. She warns you that we must be vigilant, for should we let out down our guard, the Rat King will return. As payment, @Pandah offers you several rat eggs. Noticing your uneasy expression, she smiles, \"They make wonderful pets.\"",
+  "questRatCompletion": "Your final strike saps the gargantuan rat's strength, his eyes fading to a dull grey. The beast splits into many tiny rats, which scurry off in fright. You notice @Pandah standing behind you, looking at the once mighty creature. She explains that the citizens of Habitica have been inspired by your courage and are quickly completing all their unchecked dailies. She warns you that we must be vigilant, for should we let down our guard, the Rat King will return. As payment, @Pandah offers you several rat eggs. Noticing your uneasy expression, she smiles, \"They make wonderful pets.\"",
   "questRatBoss": "Rat King",
   "questRatDropRatEgg": "Rat (Egg)",
 
@@ -43,7 +43,7 @@
 
   "questVice2Text": "Find the Lair of the Wyrm",
   "questVice2Notes": "With Vice's influence over you dispelled, you feel a surge of strength you didn't know you had return to you. Confident in yourselves and your ability to withstand the wyrm's influence, your party makes it's way to Mt. Habitica. You approach the entrance to the mountain's caverns and pause. Swells of shadows, almost like fog, wisp out from the opening. It is near impossible to see anything in front of you. The light from your lanterns seem to end abruptly where the shadows begin. It is said that only magical light can pierce the dragon's infernal haze. If you can find enough light crystals, you could make your way to the dragon.",
-  "questVice2CollectLightCrystal": "Vice's Shade",
+  "questVice2CollectLightCrystal": "Light Crystals",
   "questVice2DropVice3Quest": "Vice Part 3 (Scroll)",
 
   "questVice3Text": "Vice Awakens",
@@ -57,6 +57,6 @@
   "questEggHuntText": "Egg Hunt",
   "questEggHuntNotes": "Overnight, strange plain eggs have appeared everywhere: in Matt's stables, behind the counter at the Tavern, and even among the pet eggs at the Marketplace! What a nuisance! \"Nobody knows where they came from, or what they might hatch into,\" says <strong>Megan</strong>, \"but we can't just leave them laying around! Work hard and search hard to help me gather up these mysterious eggs. Maybe if you collect enough, there will be some extras left over for you...\"",
   "questEggHuntCompletion": "You did it! In gratitude, <strong>Megan</strong> gives you ten of the eggs. \"I don't think they hatch, exactly,\" she says, \"and they certainly won't grow into mounts. But that doesn't mean you can't dye them beautiful colors!\"",
-  "questEggHuntCollectPlainEgg": "Plain Egg",
+  "questEggHuntCollectPlainEgg": "Plain Eggs",
   "questEggHuntDropPlainEgg": "Plain Egg"
 }


### PR DESCRIPTION
questVice2CollectLightCrystal had the wrong text ("Vice's Shade") - I've changed it to "Light Crystals"

For questEggHuntCollectPlainEgg, I've pluralised the text (Plain Eggs) because that reads better in the messages it appears in (and plurals are used in questEvilSanta2CollectTracks and questEvilSanta2CollectBranches).

For questRatCompletion, I've removed "out" from this: "we let out down our guard"
