### PR TITLE
fix typo : Canycane -> Candycane

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -10238,8 +10238,8 @@ gear = {
         canOwn: (function(u) {
           return u.stats["class"] === 'wizard';
         }),
-        text: t('headSpecialCanycaneText'),
-        notes: t('headSpecialCanycaneNotes', {
+        text: t('headSpecialCandycaneText'),
+        notes: t('headSpecialCandycaneNotes', {
           per: 7
         }),
         per: 7,

--- a/script/content.coffee
+++ b/script/content.coffee
@@ -179,7 +179,7 @@ gear =
       nye:        event: events.winter, text: t('headSpecialNyeText'), notes: t('headSpecialNyeNotes'), value: 0
       yeti:       event: events.winter, canOwn: ((u)->u.stats.class is 'warrior' ), text: t('headSpecialYetiText'), notes: t('headSpecialYetiNotes', {str: 9}), str: 9, value:60
       ski:        event: events.winter, canOwn: ((u)->u.stats.class is 'rogue'   ), text: t('headSpecialSkiText'), notes: t('headSpecialSkiNotes', {per: 9}), per: 9, value:60
-      candycane:  event: events.winter, canOwn: ((u)->u.stats.class is 'wizard'  ), text: t('headSpecialCanycaneText'), notes: t('headSpecialCanycaneNotes', {per: 7}), per: 7, value:60
+      candycane:  event: events.winter, canOwn: ((u)->u.stats.class is 'wizard'  ), text: t('headSpecialCandycaneText'), notes: t('headSpecialCandycaneNotes', {per: 7}), per: 7, value:60
       snowflake:  event: events.winter, canOwn: ((u)->u.stats.class is 'healer'  ), text: t('headSpecialSnowflakeText'), notes: t('headSpecialSnowflakeNotes', {int: 7}), int: 7, value:60
       # Spring Fling
       springRogue:    event: events.spring, specialClass: 'rogue',   text: t('headSpecialSpringRogueText'), notes: t('headSpecialSpringRogueNotes', {per: 9}),value: 40,per: 9


### PR DESCRIPTION
"Candycane" had the "d" left out in headSpecialCanycaneText and headSpecialCanycaneNotes. I've inserted the "d" in all places that needed it.

I've checked all locale files and none of them had that typo. I also did a "grep -r Canycane *" through my local copies of habitrpg and habitrpg-shared and didn't find it anywhere else.
