### PR TITLE
insert messageEvolve into correct locations, replacing incorrect messageAlreadyMount

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -12831,7 +12831,7 @@ api.wrap = function(user, main) {
           if (pet === user.items.currentPet) {
             user.items.currentPet = "";
           }
-          return message = i18n.t('messageAlreadyMount', {
+          return message = i18n.t('messageEvolve', {
             egg: egg
           }, req.language);
         };

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -581,7 +581,7 @@ api.wrap = (user, main=true) ->
           # changed to -1 to mark "owned" pets
           user.items.mounts[pet] = true
           user.items.currentPet = "" if pet is user.items.currentPet
-          message = i18n.t('messageAlreadyMount', {egg: egg}, req.language)
+          message = i18n.t('messageEvolve', {egg: egg}, req.language)
 
         if food.key is 'Saddle'
           evolve()


### PR DESCRIPTION
Currently, when you feed a pet enough to turn it into a mount, you see the messageAlreadyMount notification ("You already have that mount. Try feeding another pet."). This fix changes it to the messageEvolve notification ("You have tamed <%= egg %>, let's go for a ride!").
