### PR TITLE
fix bug where an un-checked to-do with checklist removes only part of reward

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -13159,7 +13159,7 @@ api.wrap = function(user, main) {
                   return m + (i.completed ? 1 : 0);
                 }), 0) / task.checklist.length;
               }
-              if (task.type === 'todo' && direction === 'up') {
+              if (task.type === 'todo') {
                 nextDelta *= 1 + _.reduce(task.checklist, (function(m, i) {
                   return m + (i.completed ? 1 : 0);
                 }), 0);

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -792,7 +792,7 @@ api.wrap = (user, main=true) ->
               if direction is 'down' and task.type is 'daily' and options.cron
                 nextDelta *= (1 - _.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),0) / task.checklist.length)
               # If To-Do, point-match the TD per checklist item completed
-              if task.type is 'todo' and direction is 'up'
+              if task.type is 'todo'
                 nextDelta *= (1 + _.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),0))
 
             unless task.type is 'reward'


### PR DESCRIPTION
When a to-do is checked off, the rewards are increased by the number of checklist items that have been completed. However as reported in https://github.com/HabitRPG/habitrpg/issues/3474, if the to-do is later un-checked, then the rewards subtracted are not being similarly increased by the number of checklist items completed. This fix will change that - the number of checklist items completed will have an equal effect on checking and unchecking a to-do.

This of course won't fix the problem of, upon unchecking, not being able to calculate the exact value of the rewards that had been given upon checking, so there will still be a discrepancy between checking and unchecking, but it will be much smaller than it is currently.
