### PR TITLE
add correct message for equipping equipment

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -12967,7 +12967,7 @@ api.wrap = function(user, main) {
             item = content.gear.flat[key];
             if (user.items.gear[type][item.type] === key) {
               user.items.gear[type][item.type] = "" + item.type + "_base_0";
-              message = i18n.t('messageBought', {
+              message = i18n.t('messageEquipped', {
                 itemText: item.text(req.language)
               }, req.language);
             } else {

--- a/locales/cs/messages.json
+++ b/locales/cs/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> opravdu chutná <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> snědl <%= foodText %>, ale nevypadá, že by mu to chutnalo.",
     "messageBought": "Koupils <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": " <%= itemText %> nevybaven.",
     "messageMissingEggPotion": "Chybí ti buď to vejce nebo ten lektvar",
     "messageAlreadyPet": "Už tohoto mazlíčka máš. Zkus vylíhnout jinou kombinaci.",

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> ist begeistert. <%= foodText %> ist seine Lieblingsspeise!",
     "messageDontEnjoyFood": "<%= egg %> ist von <%= foodText %> nicht gerade befeister, aber würgt es hinunter.",
     "messageBought": "<%= itemText %> gekauft",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> abgelegt.",
     "messageMissingEggPotion": "Dir fehlt entweder dieses Ei oder dieser Trank",
     "messageAlreadyPet": "Du hast dieses Haustier bereits. Versuche doch eine andere Kombination.",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -10,6 +10,7 @@
   "messageLikesFood": "<%= egg %> really likes the <%= foodText %>!",
   "messageDontEnjoyFood": "<%= egg %> eats the <%= foodText %> but doesn't seem to enjoy it.",
   "messageBought": "Bought <%= itemText %>",
+  "messageEquipped": " <%= itemText %> equipped.",
   "messageUnEquipped": "<%= itemText %> un-equipped.",
   "messageMissingEggPotion": "You're missing either that egg or that potion",
   "messageAlreadyPet": "You already have that pet. Try hatching a different combination!",

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "¡A <%= egg %> le encanta <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> come <%= foodText %> pero no parece disfrutarlo.",
     "messageBought": "Has comprado <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "Has desequipado <%= itemText %>",
     "messageMissingEggPotion": "No tienes ese huevo o pocion",
     "messageAlreadyPet": "¡Ya tienes esa mascota, intenta una combinacion diferente!",

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> apprécie vraiment le/la <%= foodText %> !",
     "messageDontEnjoyFood": "<%= egg %> mange le/la <%= foodText %> mais il n'a pas l'air d'aimer ça.",
     "messageBought": "Vous avez acheté <%= itemText %>.",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> retiré·e·s.",
     "messageMissingEggPotion": "Il vous manque cet œuf ou cette potion.",
     "messageAlreadyPet": "Vous avez déjà ce familier. Essayez de faire éclore une combinaison différente !",

--- a/locales/he/messages.json
+++ b/locales/he/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> נהנה לאכול <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> אוכל את ה<%= foodText %> אבל לא נראה שהוא נהנה במיוחד.",
     "messageBought": "קנית <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "הפסקת להשתמש ב<%= itemText %>",
     "messageMissingEggPotion": "חסרה לך הביצה או התרופה הזו",
     "messageAlreadyPet": "כבר השגת חיית מחמד זו. נסה/י שילוב אחר!",

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> apprezza <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> mangia <%= foodText %>, ma non sembra piacergli molto.",
     "messageBought": "Hai comprato <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> non è più equipaggiato.",
     "messageMissingEggPotion": "Ti manca un uovo o una pozione.",
     "messageAlreadyPet": "Possiedi già quell'animale. Prova un'altra combinazione!",

--- a/locales/nl/messages.json
+++ b/locales/nl/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> vindt <%= foodText %> echt heel lekker!",
     "messageDontEnjoyFood": "<%= egg %> eet <%= foodText %> maar lijkt er niet echt van te smullen.",
     "messageBought": "Kocht <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> afgedaan.",
     "messageMissingEggPotion": "Je mist of dat ei, of dat drankje.",
     "messageAlreadyPet": "Je hebt dat dier al. Probeer een andere combinatie uit te laten komen!",

--- a/locales/pl/messages.json
+++ b/locales/pl/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> really likes the <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> eats the <%= foodText %> but doesn't seem to enjoy it.",
     "messageBought": "Bought <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> un-equipped.",
     "messageMissingEggPotion": "You're missing either that egg or that potion",
     "messageAlreadyPet": "You already have that pet. Try hatching a different combination!",

--- a/locales/pt/messages.json
+++ b/locales/pt/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> gostou muito de <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> comeu <%= foodText %>, mas parece não gostar muito.",
     "messageBought": "Comprou <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> desequipado.",
     "messageMissingEggPotion": "Está faltando o ovo ou a poção.",
     "messageAlreadyPet": "Você já possui esse mascote. Tente uma combinação diferente!",

--- a/locales/ro/messages.json
+++ b/locales/ro/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> adoră să mănânce <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> mănîncă <%= foodText %>, dar se pare că nu îi place.",
     "messageBought": "Ai cumpărat <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> dezechipat.",
     "messageMissingEggPotion": "Îţi lipseşte ori oul ori poţiunea necesară",
     "messageAlreadyPet": "Deja ai acest companion. Încearcă o altă combinaţie pentru eclozare!",

--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> доволен. <%= foodText %> — его любимая еда!",
     "messageDontEnjoyFood": "<%= egg %> все съел, но не похоже, что <%= foodText %> ему нравится.",
     "messageBought": "Куплено: <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "Снято: <%= itemText %>",
     "messageMissingEggPotion": "У вас нет нужного яйца или эликсира",
     "messageAlreadyPet": "У вас уже есть такой питомец! Попробуйте другую комбинацию!",

--- a/locales/sk/messages.json
+++ b/locales/sk/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> si pochutnalo na <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> zjedlo <%= foodText %>, ale veľmi mu to nechutí.",
     "messageBought": "Kúpené: <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "Zložené - <%= itemText %> . ",
     "messageMissingEggPotion": "Na túto kombináciu ti chýba buď vajíčko alebo liahoxír",
     "messageAlreadyPet": "Toto zvieratko už máš. Skús vyliahnuť inú kombináciu!",

--- a/locales/sv/messages.json
+++ b/locales/sv/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> gillar verkligen <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> eats the <%= foodText %> but doesn't seem to enjoy it.",
     "messageBought": "Bought <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> un-equipped.",
     "messageMissingEggPotion": "You're missing either that egg or that potion",
     "messageAlreadyPet": "You already have that pet. Try hatching a different combination!",

--- a/locales/uk/messages.json
+++ b/locales/uk/messages.json
@@ -10,6 +10,7 @@
     "messageLikesFood": "<%= egg %> really likes the <%= foodText %>!",
     "messageDontEnjoyFood": "<%= egg %> eats the <%= foodText %> but doesn't seem to enjoy it.",
     "messageBought": "Bought <%= itemText %>",
+    "messageEquipped": " <%= itemText %> equipped.",
     "messageUnEquipped": "<%= itemText %> un-equipped.",
     "messageMissingEggPotion": "You're missing either that egg or that potion",
     "messageAlreadyPet": "You already have that pet. Try hatching a different combination!",

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -649,7 +649,7 @@ api.wrap = (user, main=true) ->
             item = content.gear.flat[key]
             if user.items.gear[type][item.type] is key
               user.items.gear[type][item.type] = "#{item.type}_base_0"
-              message = i18n.t('messageBought', {itemText: item.text(req.language)}, req.language)
+              message = i18n.t('messageEquipped', {itemText: item.text(req.language)}, req.language)
             else
               user.items.gear[type][item.type] = item.key
               message = user.fns.handleTwoHanded(item,type,req)


### PR DESCRIPTION
Currently, when you put on equipment, you see the messageBought notification. There was no messageEquipped notification in the code so I've added one.

I've updated ALL locale files IN ENGLISH, following the convention already in place for using English when there is no translation (e.g., locales/pl/messages.json, locales/sv/messages.json).
