### PR TITLE
show pet's name (Flying Pig) instead of key (FlyingPig) in feed notifications

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -12841,13 +12841,13 @@ api.wrap = function(user, main) {
           if (food.target === potion) {
             userPets[pet] += 5;
             message = i18n.t('messageLikesFood', {
-              egg: egg,
+              egg: egg.text(req.language),
               foodText: food.text(req.language)
             }, req.language);
           } else {
             userPets[pet] += 2;
             message = i18n.t('messageDontEnjoyFood', {
-              egg: egg,
+              egg: egg.text(req.language),
               foodText: food.text(req.language)
             }, req.language);
           }

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -588,10 +588,10 @@ api.wrap = (user, main=true) ->
         else
           if food.target is potion
             userPets[pet] += 5
-            message = i18n.t('messageLikesFood', {egg: egg, foodText: food.text(req.language)}, req.language)
+            message = i18n.t('messageLikesFood', {egg: egg.text(req.language), foodText: food.text(req.language)}, req.language)
           else
             userPets[pet] += 2
-            message = i18n.t('messageDontEnjoyFood', {egg: egg, foodText: food.text(req.language)}, req.language)
+            message = i18n.t('messageDontEnjoyFood', {egg: egg.text(req.language), foodText: food.text(req.language)}, req.language)
           if userPets[pet] >= 50 and !user.items.mounts[pet]
             evolve()
         user.items.food[food.key]--


### PR DESCRIPTION
Currently, if you feed a flying pig, the notification says, for example, "FlyingPig" (no space between the words). This should change it to use the correct string from the appropriate locale file.
