### PR TITLE
innText update of groups.json 2nd try

### DIFF
--- a/locales/en/groups.json
+++ b/locales/en/groups.json
@@ -2,7 +2,7 @@
     "tavern": "Tavern",
     "innCheckOut": "Check Out of Inn",
     "innCheckIn": "Rest in the Inn",
-    "innText": "Whilst resting, your dailies are saved and aren't affected by day turn-over. Whether you check out tomorrow or in a week's time, you'll continue in the same state as when you checked in. Beware, though: if you are in a Quest, Bosses will still punish you for your fellow party members' mistakes!",
+    "innText": "How's your stay in the Inn? To protect you, your daily list is frozen. Your checkmarks won't be processed or cleared until tomorrow (the day after you check out). Be careful, if your party's in a Boss Battle, their misses will hurt you! Also, you won't hurt the boss. Ready to leave? Check out.",
     "lfgPosts": "Looking for Group (Party Wanted) Posts",
     "tutorial": "Tutorial",
     "glossary": "Glossary",


### PR DESCRIPTION
Trying again without incorporating username. This moves all the inn messages to "innText"
(Ideally, later this message would replace Daniel's Tavern welcome when users are resting in the inn.)
