### PR TITLE
Beastmaster: props -> congratulate (remove slang)

### DIFF
--- a/locales/en/pets.json
+++ b/locales/en/pets.json
@@ -27,7 +27,7 @@
     "noFood": "You don't have any food or saddles.",
     "beastAchievement": "You have earned the \"Beast Master\" Achievement for collecting all the pets!",
     "beastMastName": "Beast Master",
-    "beastMastText": "Has found all 90 pets (insanely difficult, give this user props!)",
+    "beastMastText": "Has found all 90 pets (insanely difficult, congratulate this user!)",
     "dropsEnabled": "Drops Enabled!",
     "itemDrop": "An item has dropped!",
     "firstDrop": "You've unlocked the Drop System! Now when you complete tasks, you have a small chance of finding an item. You just found a <strong><%= eggText %> Egg</strong>! <%= eggNotes %>",


### PR DESCRIPTION
"give this user props" is an idiomatic phrase that non-native-English speakers could have problems with, especially since "prop" is also a noun that refers to an object. 

A player in the Tavern today said, _"Yeah! Beast Master Quest Complete! :D What about this 'give this user props!', am I going to get some cool gear or sth? :D"_  I had to disappoint him with the sad truth. :)
