### PR TITLE
"No Back Accessory" for base back - fixes #3640

### DIFF
--- a/locales/en/gear.json
+++ b/locales/en/gear.json
@@ -330,8 +330,8 @@
   "shieldSpecialSummerHealerText": "Shield of the Shallows",
   "shieldSpecialSummerHealerNotes": "No one will dare to attack the coral reef when faced with this shiny shield! Adds <%= con %> points to Constitution. Limited Edition 2014 Summer Gear.",
 
-  "backBase0Text": "No Helm",
-  "backBase0Notes": "No headgear.",
+  "backBase0Text": "No Back Accessory",
+  "backBase0Notes": "No Back Accessory.",
 
   "backMystery201402Text": "Golden Wings",
   "backMystery201402Notes": "These shining wings have feathers that glitter in the sun!",


### PR DESCRIPTION
Changes the text and notes for the base back gear from "No Helm" to "No Back Accessory".
