### PR TITLE
add list of moderators to top of Tavern chat

### DIFF
--- a/locales/en/groups.json
+++ b/locales/en/groups.json
@@ -15,6 +15,8 @@
     "tavernTalk": "Tavern Talk",
     "tavernAlert1": "Note: if you're reporting a bug, the developers won't see it here. Please",
     "tavernAlert2": "use Github instead",
+    "moderatorIntro1": "Tavern and guild moderators are: ",
+    "moderatorIntro2": ". Moderators' names are always highlighted in orange or purple.",
     "party": "Party",
     "createAParty": "Create A Party",
     "noPartyText": "You are either not in a party or your party is taking a while to load. You can either create one and invite friends, or if you want to join an existing party, have them enter:",

--- a/locales/en/moderatorList.json
+++ b/locales/en/moderatorList.json
@@ -1,0 +1,3 @@
+{
+    "moderatorList": "Lemoness, redphoenix, SabreCat, lefnire, paglias, wc8, Breadstrings, Daniel the Bard, Megan, Ryan, Alys"
+}

--- a/locales/en/moderatorList_README.md
+++ b/locales/en/moderatorList_README.md
@@ -1,0 +1,9 @@
+Suggestion:
+
+Do NOT copy this file to the other language folders because it
+contains nothing but people's names and hence won't need to be
+translated. The names are likely to change every so often, so
+unnecessary copies are good to avoid.
+
+An exception would be for languages (if any) where commas are not used
+to separate words in a list.


### PR DESCRIPTION
Add moderator names (moderatorList.json) and associated text (moderatorIntro\* in groups.json) for displaying at the top of Tavern chat.

I'm not sure what you'll think of my decision to put the names in a file by themselves - I think it will be most convenient to avoid unnecessary Transifex changes when/if the names change, but I might be wrong. I can move the names into groups.json if desired.

See https://github.com/HabitRPG/habitrpg/pull/3661 for the jade file that uses this JSON data.
