### PR TITLE
explain what clearCompleted does and label button more clearly

### DIFF
--- a/locales/en/tasks.json
+++ b/locales/en/tasks.json
@@ -1,6 +1,7 @@
 {
-    "clearCompleted": "Clear Completed",
+    "clearCompleted": "Delete Completed",
     "lotOfToDos": "Completed To-Dos are automatically archived after 3 days. You can access them from Options > Settings > Data Export.",
+    "deleteToDosExplanation": "If you click the button below, all of your completed To-Dos and archived To-Dos will be permanently deleted. Export them first if you want to keep a record of them.",
     "habits": "Habits",
     "newHabit": "New Habit",
     "edit": "Edit",


### PR DESCRIPTION
I'm pretty sure some people don't realise that the "Clear Completed" button permanently deletes all of their completed to-dos. The current wording around the button could be thought to imply that "clear" means "archive immediately". This change makes it obvious what will happen.

See also https://github.com/HabitRPG/habitrpg/pull/3670
