### PR TITLE
change quest warning to match current behaviour

### DIFF
--- a/locales/en/quests.json
+++ b/locales/en/quests.json
@@ -32,7 +32,7 @@
     "mustLvlQuest": "You must be level <%= level %> to buy this quest!",
     "sureAbort": "Are you sure you want to abort this mission? It will abort it for everyone in your party, all progress will be lost.",
     "doubleSureAbort": "Are you double sure? Make sure they won't hate you forever!",
-    "questWarning": "Remember: only current party members will be invited. Once the invitation is sent, no new party members can join the quest!",
+    "questWarning": "If new players join the party before the quest starts, they will also receive an invitation. However once the quest has started, no new party members can join the quest.",
     "bossRageTitle": "Rage",
     "bossRageDescription": "When this bar fills, the boss will unleash a special attack"
 }


### PR DESCRIPTION
This text change matches how quests actually behave now.

I've tested the quest behaviour like this:
- create a party with two accounts
- use one account to invite the other to a quest
- DON'T let the second account accept the quest (so the quest does not start)
- invite a third member into the party -> the third member receives a quest invitation
