### PR TITLE
[HabitRPG/habitrpg#3260] Buttonless habit full width

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -260,6 +260,7 @@ api.taskClasses = (task, filters=[], dayStart=0, lastCron=+new Date, showComplet
       classes += " uncompleted"
   else if type is 'habit'
     classes += ' habit-wide' if task.down and task.up
+    classes += ' habit-narrow' if !task.down and !task.up
 
   if value < -20
     classes += ' color-worst'


### PR DESCRIPTION
When the user has neither a plus nor a minus button on
one of their habits, the habit’s title will now span the entire
width of the task div instead of having a gap to the left.
