### PR TITLE
Change newPassSent to reflect 'Reset Password' not failing on non-existent email.

### DIFF
--- a/locales/en/generic.json
+++ b/locales/en/generic.json
@@ -54,7 +54,7 @@
     "untilNoFace": "Until we add Facebook, use your UUID and API Token to log in (found at https://habitrpg.com > Options > Settings).",
     "noReachServer": "Server not currently reachable, try again later",
     "errorUpCase": "ERROR:",
-    "newPassSent": "New password sent.",
+    "newPassSent": "New password sent if an account is registered to this email address.",
     "serverUnreach": "Server currently unreachable.",
     "seeConsole": "(see Chrome console for more details).",
     "error": "Error",


### PR DESCRIPTION
See habitrpg/habitrpg#3814 for more info.
