### PR TITLE
Fix User Reset

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -414,6 +414,7 @@ api.wrap = (user, main=true) ->
           gear[type].weapon = 'weapon_base_0'
           gear[type].head   = 'head_base_0'
           gear[type].shield = 'shield_base_0'
+        gear.owned = {} if typeof gear.owned == 'undefined';
         _.each gear.owned, (v, k)-> gear.owned[k]=false if gear.owned[k];true
         gear.owned.weapon_warrior_0 = true
         user.markModified? 'items.gear.owned'


### PR DESCRIPTION
5cd0039 added regression where reset on new user would fail because user.items.gear.owned is undefined.
This patch allows tests to get _much_ further than before.
