### PR TITLE
Fix freeRebirth flag

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1155,7 +1155,7 @@ api.wrap = (user, main=true) ->
           dialog: i18n.t('messageFoundQuest', {questText: content.quests.vice1.text(req.language)}, req.language)
       if !user.flags.rebirthEnabled and (user.stats.lvl >= 50 or user.achievements.ultimateGear or user.achievements.beastMaster)
         user.flags.rebirthEnabled = true
-      if !user.flags.freeRebirth = true and user.stats.lvl >= 100
+      if user.stats.lvl >= 100 and !user.flags.freeRebirth = true
         user.flags.freeRebirth = true
 
     ###


### PR DESCRIPTION
Coffee is assuming the negation (!) applies to the AND of the two tests
should be just !user.flags.freeRebirth = true.  Fixes 4 test errors.

UserID: 7941e218-7b6e-42b7-989d-8b040c65aa17
