### PR TITLE
Fix: OK for unpurchaseable quest to have no value

### DIFF
--- a/test/algos.mocha.coffee
+++ b/test/algos.mocha.coffee
@@ -308,7 +308,7 @@ describe 'User', ->
         expect(quest.notes()).to.be.an('string')
         expect(quest.completion()).to.be.an('string') if quest.completion
         expect(quest.previous).to.be.an('string') if quest.previous
-        expect(quest.value).to.be.greaterThan 0
+        expect(quest.value).to.be.greaterThan 0 if quest.canBuy
         expect(quest.drop.gp).to.not.be.lessThan 0
         expect(quest.drop.exp).to.not.be.lessThan 0
         expect(quest.drop.items).to.be.an(Array)


### PR DESCRIPTION
Changing test to only check that a quest has value if it is "canBuy=true".
This (with PR#262) should fix the last test error on habitrpg-shared.

UserID: 7941e218-7b6e-42b7-989d-8b040c65aa17
