### PR TITLE
remove redundant message in Tavern now that mod names are styled 

### DIFF
--- a/locales/en/groups.json
+++ b/locales/en/groups.json
@@ -16,7 +16,7 @@
     "tavernAlert1": "Note: if you're reporting a bug, the developers won't see it here. Please",
     "tavernAlert2": "use Github instead",
     "moderatorIntro1": "Tavern and guild moderators are: ",
-    "moderatorIntro2": ". Moderators' names are always highlighted in purple or blue.",
+    "moderatorIntro2": ".",
     "party": "Party",
     "createAParty": "Create A Party",
     "noPartyText": "You are either not in a party or your party is taking a while to load. You can either create one and invite friends, or if you want to join an existing party, have them enter:",


### PR DESCRIPTION
Do not merge until https://github.com/HabitRPG/habitrpg/pull/3825 is merged.

This PR removes the text "Moderators' names are always highlighted in orange or purple" from the message that appears above the Tavern chat. See the screenshots in https://github.com/HabitRPG/habitrpg/pull/3825
