### PR TITLE
add text to be used to mark quest owner in quest participants box on party page

### DIFF
--- a/locales/en/quests.json
+++ b/locales/en/quests.json
@@ -21,6 +21,7 @@
     "bossColl1": "To collect items, do your positive tasks. Quest items drop just like normal items; however, you won't see the drops until the next day, then everything you've found will be tallied up and contributed to the pile.",
     "bossColl2": "Only participants can collect items and share in the quest loot.",
     "abort": "Abort",
+    "questOwner": "Quest Owner",
     "scrolls": "Quest Scrolls",
     "noScrolls": "You don't have any quest scrolls.",
     "scrollsText1": "Quests require parties. If you want to quest solo,",


### PR DESCRIPTION
Goes along with this pull request: https://github.com/HabitRPG/habitrpg/pull/3966
