### PR TITLE
add support for pushTaskToBottom to help with To-Do sort order bug

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -13283,7 +13283,7 @@ api.wrap = function(user, main) {
         return typeof cb === "function" ? cb(null, user.todos) : void 0;
       },
       sortTask: function(req, cb) {
-        var from, id, task, tasks, to, _ref;
+        var from, id, movedTask, task, tasks, to, _ref;
         id = req.params.id;
         _ref = req.query, to = _ref.to, from = _ref.from;
         task = user.tasks[id];
@@ -13297,7 +13297,12 @@ api.wrap = function(user, main) {
           return typeof cb === "function" ? cb('?to=__&from=__ are required') : void 0;
         }
         tasks = user["" + task.type + "s"];
-        tasks.splice(to, 0, tasks.splice(from, 1)[0]);
+        movedTask = tasks.splice(from, 1)[0];
+        if (to === -1) {
+          tasks.push(movedTask);
+        } else {
+          tasks.splice(to, 0, movedTask);
+        }
         return typeof cb === "function" ? cb(null, tasks) : void 0;
       },
       updateTask: function(req, cb) {
@@ -13520,6 +13525,12 @@ api.wrap = function(user, main) {
           return typeof cb === "function" ? cb({
             code: 401,
             message: i18n.t('messageNotEnoughGold', req.language)
+          }) : void 0;
+        }
+        if ((item.canOwn != null) && !item.canOwn(user)) {
+          return typeof cb === "function" ? cb({
+            code: 401,
+            message: "You can't own this item"
           }) : void 0;
         }
         if (item.key === 'potion') {

--- a/locales/en/tasks.json
+++ b/locales/en/tasks.json
@@ -61,5 +61,6 @@
     "fortifyText": "Fortify will return all your tasks to a neutral (yellow) state, as if you'd just added them, and top your Health off to full. Consider this an option of last resort! Red tasks provide good incentive to improve. But if all that red fills you with despair, and the beginning of each new day proves lethal, spend the Gems and catch a reprieve!",
     "sureDelete": "Are you sure you want to delete this task?",
     "streakCoins": "Streak Bonus!",
-    "pushTaskToTop": "Push task to top"
+    "pushTaskToTop": "Push task to top",
+    "pushTaskToBottom": "Push task to bottom"
 }

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -517,7 +517,11 @@ api.wrap = (user, main=true) ->
         return cb?({code:404, message: i18n.t('messageTaskNotFound', req.language)}) unless task
         return cb?('?to=__&from=__ are required') unless to? and from?
         tasks = user["#{task.type}s"]
-        tasks.splice to, 0, tasks.splice(from, 1)[0]
+        movedTask = tasks.splice(from, 1)[0]
+        if to == -1 # we've used the Push To Bottom feature
+          tasks.push(movedTask)
+        else  # any other sort method uses only positive 'to' values
+          tasks.splice(to, 0, movedTask)
         cb? null, tasks
 
       updateTask: (req, cb) ->


### PR DESCRIPTION
Goes along with https://github.com/HabitRPG/habitrpg/pull/4007

Implements SabreCat's idea for a workaround for the To-Do sorting bug: https://github.com/HabitRPG/habitrpg/issues/2606#issuecomment-53584917

Also allows future implementation of a manual pushTaskToBottom button, should we want that.
