### PR TITLE
add noMount flag for Plain Eggs to hide them on Mounts page

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -11406,7 +11406,8 @@ api.questEggs = {
   Egg: {
     text: t('questEggEggText'),
     adjective: t('questEggEggAdjective'),
-    canBuy: false
+    canBuy: false,
+    noMount: true
   },
   Rat: {
     text: t('questEggRatText'),
@@ -14471,5 +14472,5 @@ api.wrap = function(user, main) {
 };
 
 
-}).call(this,require("/Users/lefnire/Dropbox/Sites/habitrpg/modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js"))
-},{"./content.coffee":5,"./i18n.coffee":6,"/Users/lefnire/Dropbox/Sites/habitrpg/modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js":2,"lodash":3,"moment":4}]},{},[1])
+}).call(this,require("/vagrant/node_modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js"))
+},{"./content.coffee":5,"./i18n.coffee":6,"/vagrant/node_modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js":2,"lodash":3,"moment":4}]},{},[1])

--- a/script/content.coffee
+++ b/script/content.coffee
@@ -627,7 +627,7 @@ api.questEggs =
   Gryphon:          text: t('questEggGryphonText'),  adjective: t('questEggGryphonAdjective'), canBuy: false
   Hedgehog:         text: t('questEggHedgehogText'), adjective: t('questEggHedgehogAdjective'), canBuy: false
   Deer:             text: t('questEggDeerText'), adjective: t('questEggDeerAdjective'), canBuy: false
-  Egg:              text: t('questEggEggText'), adjective: t('questEggEggAdjective'), canBuy: false
+  Egg:              text: t('questEggEggText'), adjective: t('questEggEggAdjective'), canBuy: false, noMount: true
   Rat:              text: t('questEggRatText'), adjective: t('questEggRatAdjective'), canBuy: false
   Octopus:          text: t('questEggOctopusText'), adjective: t('questEggOctopusAdjective'), canBuy: false
   Seahorse:         text: t('questEggSeahorseText'), adjective: t('questEggSeahorseAdjective'), canBuy: false


### PR DESCRIPTION
... so that we never have to answer that question again

Goes along with https://github.com/HabitRPG/habitrpg/pull/4019

Fixes https://github.com/HabitRPG/habitrpg/issues/3240
