### PR TITLE
Fix percent function to return minimum zero

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -199,7 +199,7 @@ api.percent = (x,y, dir) ->
     when "down" then roundFn = Math.floor
     else roundFn = Math.round
   x=1 if x==0
-  roundFn(x/y*100)
+  Math.max(0,roundFn(x/y*100))
 
 ###
 Remove whitespace #FIXME are we using this anywwhere? Should we be?


### PR DESCRIPTION
The percent function is used for ui-bars. When returning numbers below zero the bar will show up with 100% width, 'cause css don't know negative width. Issue #3886
