### PR TITLE
add coverage tools to habitrpg-shared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage.html
 node_modules
 npm-debug.log
 .idea

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "grunt-spritesmith": "~1.22.0"
   },
   "devDependencies": {
+    "coffee-coverage": "~0.4.2",
     "mocha": "*",
     "expect.js": "*",
     "sinon": "~1.8.2",
@@ -21,6 +22,7 @@
     "image-size": "~0.3.2"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "coverage": "COVERAGE=true mocha --require register-handlers.js --reporter html-cov > coverage.html"
   }
 }

--- a/register-handlers.js
+++ b/register-handlers.js
@@ -1,0 +1,7 @@
+if(process.env.COVERAGE) {
+    require('coffee-coverage').register({
+        path: 'abbr',
+        basePath: __dirname + '/script',
+        initAll: true,
+    });
+}


### PR DESCRIPTION
This should help with #174, though it only has coverage for the .coffee files, not the pure js.  As far as I can tell, though, that's all we're actually testing now.

I spent a while trying out some other tools for coverage, but ibrik couldn't process some of the files and karma-coverage seems to use ibrik to preprocess coffeescript.  Nothing seemed to cover both the js and the coffeescript well.

This is very easy to use - `npm run coverage` will generate a coverage.html file with nicely formatted coverage information.

I'm new to node, so please let me know if I'm doing something weird or violating best practices in some way.
