### PR TITLE
add more on-hover text to Mystery Item box to explain when it is released

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -14525,5 +14525,5 @@ api.wrap = function(user, main) {
 };
 
 
-}).call(this,require("/Users/lefnire/Dropbox/Sites/habitrpg/modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js"))
-},{"./content.coffee":5,"./i18n.coffee":6,"/Users/lefnire/Dropbox/Sites/habitrpg/modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js":2,"lodash":3,"moment":4}]},{},[1])
+}).call(this,require("/vagrant/node_modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js"))
+},{"./content.coffee":5,"./i18n.coffee":6,"/vagrant/node_modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js":2,"lodash":3,"moment":4}]},{},[1])

--- a/locales/en/generic.json
+++ b/locales/en/generic.json
@@ -15,7 +15,7 @@
     "market": "Market",
     "subscriberItem": "Mystery Item",
     "newSubscriberItem": "New Mystery Item",
-    "subscriberItemText": "Each month, subscribers will receive a mystery item.",
+    "subscriberItemText": "Each month, subscribers will receive a mystery item. This is usually released about one week before the end of the month. See the wiki's 'Mystery Item' page for the exact date.",
     "all": "All",
     "none": "None",
     "or": "Or",


### PR DESCRIPTION
We get a lot of questions about when Mystery Items will be released, both towards the end of each month and during the month when new subscribers sign up and wonder if they should get the items immediately. This PR adds the final two sentences you can see here:

![screen shot 2014-09-20 at 11 06 53 am](https://cloud.githubusercontent.com/assets/1495809/4343811/bc67daea-4063-11e4-9c28-1584f3d2f55b.png)

I'll merge this in a day or two if there's no complaints.
