### PR TITLE
Remove challenges when reset (habitrpg - Bug #4090)

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -409,6 +409,7 @@ api.wrap = (user, main=true) ->
         user.dailys = []
         user.todos = []
         user.rewards = []
+        user.challenges = []
         user.stats.hp = 50
         user.stats.lvl = 1
         user.stats.gp = 0


### PR DESCRIPTION
Sets challenges to an empty array when reset is implemented
