### PR TITLE
Remove the right amount of gold and exp when unchecking a task

### DIFF
--- a/test/algos.mocha.coffee
+++ b/test/algos.mocha.coffee
@@ -93,6 +93,11 @@ expectNoChange = (before,after) ->
   _.each $w('stats items gear dailys todos rewards flags preferences'), (attr)->
     expect(after[attr]).to.eql before[attr]
 
+expectClosePoints = (before, after, taskType) ->
+  expect( Math.abs(after.stats.exp - before.stats.exp) ).to.be.lessThan 0.0001
+  expect( Math.abs(after.stats.gp - before.stats.gp) ).to.be.lessThan 0.0001
+  expect( Math.abs(after["#{taskType}s"][0].value - before["#{taskType}s"][0].value) ).to.be.lessThan 0.0001
+
 expectDayResetNoDamage = (b,a) ->
   [before,after] = [_.cloneDeep(b), _.cloneDeep(a)]
   _.each after.dailys, (task,i) ->
@@ -379,9 +384,19 @@ describe 'Simple Scoring', ->
     @after.ops.score {params: {id: @after.dailys[0].id, direction: 'up'}}
     expectGainedPoints(@before, @after,'daily')
 
+  it 'Dailys : Up, Down', ->
+    @after.ops.score {params: {id: @after.dailys[0].id, direction: 'up'}}
+    @after.ops.score {params: {id: @after.dailys[0].id, direction: 'down'}}
+    expectClosePoints(@before, @after, 'daily')
+
   it 'Todos : Up', ->
     @after.ops.score {params: {id: @after.todos[0].id, direction: 'up'}}
     expectGainedPoints(@before, @after,'todo')
+
+  it 'Todos : Up, Down', ->
+    @after.ops.score {params: {id: @after.todos[0].id, direction: 'up'}}
+    @after.ops.score {params: {id: @after.todos[0].id, direction: 'down'}}
+    expectClosePoints(@before, @after, 'todo')
 
 describe 'Cron', ->
 


### PR DESCRIPTION
There are a lot of code changes for this, but a good portion of it is splitting calculateDelta() into two functions.  The idea here is when a task is unchecked the gold and experience removed is different from the amount added.  When we uncheck a task, we need to change the task back to its original value (which involves approximating what that original value was), then calculate the delta off of the original value.  That delta can then be used for the exp and gold calculation.

I tested the approximation code for over 600,000 values between -47.27 and 21.27 and it always approximates the original value in 2 to 4 iterations, so this shouldn't affect anything speed wise.  I can upload the python code i wrote to test it, if you would like.

This doesn't fix any issues with finding an item on an accidental click, but at least the numbers come out the same now.

This fixes issue HabitRPG/habitrpg#964 along with countless other ones that I won't mention here :)
