### PR TITLE
Fixed cron dayStart option.

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -42,7 +42,10 @@ api.startOfWeek = api.startOfWeek = (options={}) ->
 
 api.startOfDay = (options={}) ->
   o = sanitizeOptions(options)
-  moment(o.now).startOf('day').add({hours:o.dayStart})
+  dayStart = moment(o.now).startOf('day').add({hours:o.dayStart})
+  if moment(o.now).hour() < o.dayStart
+    dayStart.subtract({days:1})
+  dayStart
 
 api.dayMapping = {0:'su',1:'m',2:'t',3:'w',4:'th',5:'f',6:'s'}
 
@@ -51,7 +54,7 @@ api.dayMapping = {0:'su',1:'m',2:'t',3:'w',4:'th',5:'f',6:'s'}
 ###
 api.daysSince = (yesterday, options = {}) ->
   o = sanitizeOptions options
-  Math.abs api.startOfDay(_.defaults {now:yesterday}, o).diff(o.now, 'days')
+  Math.abs api.startOfDay(_.defaults {now:yesterday}, o).diff(api.startOfDay(_.defaults {now:o.now}, o), 'days')
 
 ###
   Should the user do this taks on this date, given the task's repeat options and user.preferences.dayStart?
@@ -60,13 +63,7 @@ api.shouldDo = (day, repeat, options={}) ->
   return false unless repeat
   o = sanitizeOptions options
   selected = repeat[api.dayMapping[api.startOfDay(_.defaults {now:day}, o).day()]]
-  return selected unless moment(day).zone(o.timezoneOffset).isSame(o.now,'d')
-  if options.dayStart <= o.now.hour() # we're past the dayStart mark, is it due today?
-    return selected
-  else # we're not past dayStart mark, check if it was due "yesterday"
-    yesterday = moment(o.now).subtract({days:1}).day() # have to wrap o.now so as not to modify original
-    return repeat[api.dayMapping[yesterday]] # FIXME is this correct?? Do I need to do any timezone calcaulation here?
-
+  return selected
 
 ###
   ------------------------------------------------------

--- a/test/algos.mocha.coffee
+++ b/test/algos.mocha.coffee
@@ -56,6 +56,9 @@ expectStrings = (obj, paths) ->
   _.each paths, (path) -> expect(obj[path]).to.be.ok()
 
 # options.daysAgo: days ago when the last cron was executed
+# cronAfterStart: moves the lastCron to be after the dayStart.
+#  This way the daysAgo works as expected if the test case
+#  makes the assumption that the lastCron was after dayStart.
 beforeAfter = (options={}) ->
   user = newUser()
   [before, after] = [user, _.cloneDeep(user)]
@@ -66,7 +69,9 @@ beforeAfter = (options={}) ->
   if options.limitOne
     before["#{options.limitOne}s"] = [before["#{options.limitOne}s"][0]]
     after["#{options.limitOne}s"] = [after["#{options.limitOne}s"][0]]
-  lastCron = +(moment(options.now || +new Date).subtract('days', options.daysAgo)) if options.daysAgo
+  lastCron = moment(options.now || +new Date).subtract( {days:options.daysAgo} ) if options.daysAgo
+  lastCron.add( {hours:options.dayStart, minutes:1} ) if options.daysAgo and options.cronAfterStart
+  lastCron = +lastCron if options.daysAgo
   _.each [before,after], (obj) ->
     obj.lastCron = lastCron if options.daysAgo
   {before:before, after:after}
@@ -509,6 +514,59 @@ describe 'Cron', ->
       expect(after.todos[0].value).to.be.lessThan before.todos[0].value
       expect(after.history.todos).to.have.length 1
 
+  # I used hard-coded dates here instead of 'now' so the tests don't fail
+  #  when you run them between midnight and dayStart. Nothing worse than
+  #  intermittent failures.
+  describe 'cron day calculations', ->
+    dayStart = 4
+    fstr = "YYYY-MM-DD HH:mm:ss"
+
+    it 'startOfDay before dayStart', ->
+      # If the time is before dayStart, then we expect the start of the day to be yesterday at dayStart
+      start = shared.startOfDay {now: moment('2014-10-09 02:30:00'), dayStart}
+      expect(start.format(fstr)).to.eql '2014-10-08 04:00:00'
+
+    it 'startOfDay after dayStart', ->
+      # If the time is after dayStart, then we expect the start of the day to be today at dayStart
+      start = shared.startOfDay {now: moment('2014-10-09 05:30:00'), dayStart}
+      expect(start.format(fstr)).to.eql '2014-10-09 04:00:00'
+
+    it 'daysSince cron before, now after', ->
+      # If the lastCron was before dayStart, then a time on the same day after dayStart
+      #  should be 1 day later than lastCron
+      lastCron = moment('2014-10-09 02:30:00')
+      days = shared.daysSince(lastCron, {now: moment('2014-10-09 11:30:00'), dayStart})
+      expect(days).to.eql 1
+
+    it 'daysSince cron before, now before', ->
+      # If the lastCron was before dayStart, then a time on the same day also before dayStart
+      #  should be 0 days later than lastCron
+      lastCron = moment('2014-10-09 02:30:00')
+      days = shared.daysSince(lastCron, {now: moment('2014-10-09 03:30:00'), dayStart})
+      expect(days).to.eql 0
+
+    it 'daysSince cron after, now after', ->
+      # If the lastCron was after dayStart, then a time on the same day also after dayStart
+      #  should be 0 days later than lastCron
+      lastCron = moment('2014-10-09 05:30:00')
+      days = shared.daysSince(lastCron, {now: moment('2014-10-09 06:30:00'), dayStart})
+      expect(days).to.eql 0
+
+    it 'daysSince cron after, now tomorrow before', ->
+      # If the lastCron was after dayStart, then a time on the following day but before dayStart
+      #  should be 0 days later than lastCron
+      lastCron = moment('2014-10-09 12:30:00')
+      days = shared.daysSince(lastCron, {now: moment('2014-10-10 01:30:00'), dayStart})
+      expect(days).to.eql 0
+
+    it 'daysSince cron after, now tomorrow after', ->
+      # If the lastCron was after dayStart, then a time on the following day and after dayStart
+      #  should be 1 day later than lastCron
+      lastCron = moment('2014-10-09 12:30:00')
+      days = shared.daysSince(lastCron, {now: moment('2014-10-10 10:30:00'), dayStart})
+      expect(days).to.eql 1
+
+
   describe 'dailies', ->
 
     describe 'new day', ->
@@ -522,7 +580,7 @@ describe 'Cron', ->
       runCron = (options) ->
         _.each [480, 240, 0, -120], (timezoneOffset) -> # test different timezones
           now = shared.startOfWeek({timezoneOffset}).add('hours', options.currentHour||0)
-          {before,after} = beforeAfter({now, timezoneOffset, daysAgo:1, dayStart:options.dayStart||0, limitOne:'daily'})
+          {before,after} = beforeAfter({now, timezoneOffset, daysAgo:1, cronAfterStart:options.cronAfterStart||true, dayStart:options.dayStart||0, limitOne:'daily'})
           before.dailys[0].repeat = after.dailys[0].repeat = options.repeat if options.repeat
           before.dailys[0].streak = after.dailys[0].streak = 10
           before.dailys[0].completed = after.dailys[0].completed = true if options.checked
@@ -536,11 +594,14 @@ describe 'Cron', ->
             when 'noDamage' then expectDayResetNoDamage(before,after)
           {before,after}
 
+      # These test cases were written assuming that lastCron was run after dayStart
+      #  even if currentHour < dayStart and lastCron = yesterday at currentHour.
+      #  cronAfterStart makes sure that lastCron is moved to be after dayStart.
       cronMatrix =
         steps:
 
           'due yesterday':
-            defaults: {daysAgo:1, limitOne: 'daily'}
+            defaults: {daysAgo:1, cronAfterStart:true, limitOne: 'daily'}
             steps:
 
               '(simple)': {expect:'losePoints'}
@@ -591,15 +652,8 @@ describe 'Cron', ->
           it "#{options.text}", -> runCron(_.defaults(obj,options))
       recurseCronMatrix(cronMatrix)
 
-    it 'calculates day differences with dayStart properly', ->
-      dayStart = 4
-      yesterday = shared.startOfDay {now: moment().subtract('d', 1), dayStart}
-      now = shared.startOfDay {dayStart: dayStart-1}
-      expect(shared.daysSince(yesterday, {now, dayStart})).to.eql 0
-      now = moment().startOf('day').add('h', dayStart).add('m', 1)
-      expect(shared.daysSince(yesterday, {now, dayStart})).to.eql 1
-
 describe 'Helper', ->
+
   it 'calculates gold coins', ->
     expect(shared.gold(10)).to.eql 10
     expect(shared.gold(1.957)).to.eql 1
@@ -618,9 +672,15 @@ describe 'Helper', ->
     expect(shared.tnl 99).to.eql 3580
 
   it 'calculates the start of the day', ->
-    expect(shared.startOfDay({now: new Date(2013, 0, 1, 0)}).format('YYYY-MM-DD HH:mm')).to.eql '2013-01-01 00:00'
-    expect(shared.startOfDay({now: new Date(2013, 0, 1, 5)}).format('YYYY-MM-DD HH:mm')).to.eql '2013-01-01 00:00'
-    expect(shared.startOfDay({now: new Date(2013, 0, 1, 23, 59, 59)}).format('YYYY-MM-DD HH:mm')).to.eql '2013-01-01 00:00'
+    fstr = 'YYYY-MM-DD HH:mm:ss'
+    today = '2013-01-01 00:00:00'
+    # get the timezone for the day, so the test case doesn't fail
+    #  if you run it during daylight savings time because by default
+    #  it uses moment().zone() which is the current minute offset
+    zone = moment(today).zone()
+    expect(shared.startOfDay({now: new Date(2013, 0, 1, 0)}, timezoneOffset:zone).format(fstr)).to.eql today
+    expect(shared.startOfDay({now: new Date(2013, 0, 1, 5)}, timezoneOffset:zone).format(fstr)).to.eql today
+    expect(shared.startOfDay({now: new Date(2013, 0, 1, 23, 59, 59), timezoneOffset:zone}).format(fstr)).to.eql today
 
   it 'counts pets', ->
     pets = {}


### PR DESCRIPTION
This has been said before, but I think I fixed the cron issues with dayStart.

The issue comes when the last cron was after midnight and before dayStart.  Then when you attempt a cron again on the same day, but after dayStart, it doesn't compute the daysSince correctly.  I adjusted startOfDay to take dayStart into account.  So, when dayStart = 4 and lastCron = '2014-10-09 01:30:00' then startOfDay will return '2014-10-08 04:00:00' since technically our day doesn't start until 4am.  This makes the code for both daysSince and shouldDo simpler because we just alter which day we consider a certain timestamp to be at.

In daysSince I didn't use the diff 'true' parameter or use a smaller diff interval with Math.ceil as was suggested earlier because I compute the startDay of both yesterday and now.  So, both dates will be set to dayStart.  They might have a difference in date, but not in time, so the diff will always be a whole number.

I wrote a number of test cases for startDay and daysSince to verify they are correct. Some of the test cases in Cron->dailies->new day were incorrect.  For example: "due yesterday  due today  pre-dayStart  checked" was expecting cron not to run even though dayStart = 4, lastCron = '2014-10-09 03:00:00', and now = '2014-10-10 03:00:00'.  The incorrect tests were assuming that lastCron always happened after dayStart, even though lastCron was being set before dayStart.

I removed the test "calculates day differences with dayStart properly" because with the fixed cron the test would fail if you ran it between midnight and dayStart and pass other times.  The new tests I created should cover the same cases as this test, so I just removed it.

I also fixed the test "calculates the start of the day" for the time at 23:59:59.  The issue here was the date is in January, but the function wasn't given a timezone, so it defaults to now's timezone.  So, the test case fails if you run it while in daylight savings time because the timezone offset is different.  Passing in the timezone for January fixes this issue.

Should fix (crossing my fingers) issue HabitRPG/habitrpg#1057
