### PR TITLE
Shortened title so popover glitch would be fixed

### DIFF
--- a/locales/en/character.json
+++ b/locales/en/character.json
@@ -42,7 +42,7 @@
     "equipmentBonusText": "Attribute bonuses provided by your equipped battle gear. See the Equipment tab under Inventory to select your battle gear.",
     "classBonus": "Class Equipment Bonus",
     "classBonusText": "Your class (Warrior, if you haven't unlocked or selected another class) uses its own equipment more effectively than gear from other classes. Equipped gear from your current class gets a 50% boost to the attribute bonus it grants.",
-    "classEquipBonus": "Class Equip Bonus",
+    "classEquipBonus": "Class Bonus",
     "battleGear": "Battle Gear",
     "battleGearText": "This is the gear you wear into battle, it affects numbers when interacting with your tasks.",
     "costume": "Costume",


### PR DESCRIPTION
When clicking on party member, a modal pops up. The "Class Equip Bonus" is wrapping to the next line. For some reason, the wrapping is causing the popover to flash briefly and then disappear. If you get your mouse in just the right spot, it'll appear correctly. Shortening the string fixes the problem.

![skitch](https://cloud.githubusercontent.com/assets/2916945/4682344/f08f5bd6-561b-11e4-95d5-d9a3b24294c9.jpg)

I propose shortening the string to "Class Bonus". Hovering over it will show the full title "Class Equipment Bonus" and give an explanation of what it is, so I don't think it's a big deal to shorten it to "Class Bonus".

Thoughts?
