### PR TITLE
Added space before "target=" when added to href

### DIFF
--- a/script/directives.js
+++ b/script/directives.js
@@ -98,7 +98,7 @@
           
           html = html.replace(userHighlight, "<u>@"+userName+"</u>");
           
-          html = html.replace(' href','target="'+linktarget+'" href');
+          html = html.replace(' href',' target="'+linktarget+'" href');
           element.html(html);
         });
       }
@@ -109,7 +109,7 @@
     return function(input){
       var html = md.toHtml(input);
       
-      html = html.replace(' href','target="_self" href');
+      html = html.replace(' href',' target="_self" href');
       
       return html;
     };


### PR DESCRIPTION
Fixes bug where the first links in markdown boxes don't work
![screen shot 2014-11-01 at 10 35 43 pm](https://cloud.githubusercontent.com/assets/500587/4872653/8e45bdd4-61ed-11e4-9fc4-737df7163d2c.png)
![screen shot 2014-11-01 at 10 35 21 pm](https://cloud.githubusercontent.com/assets/500587/4872655/8e4f7284-61ed-11e4-88e2-c988a68245d7.png)
![screen shot 2014-11-01 at 10 35 13 pm](https://cloud.githubusercontent.com/assets/500587/4872654/8e4c1814-61ed-11e4-83d2-12365cb04f3b.png)
