### PR TITLE
Diminish critical hit bonus towards 450%

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1077,7 +1077,9 @@ api.wrap = (user, main=true) ->
 
     crit: (stat='str', chance=.03) ->
       #console.log("Crit Chance:"+chance*(1+user._statsComputed[stat]/100))
-      if user.fns.predictableRandom() <= chance*(1+user._statsComputed[stat]/100) then 1.5 + (.02*user._statsComputed[stat])
+      s = user._statsComputed[stat]
+      if user.fns.predictableRandom() <= chance*(1 + s/100)
+        1.5 + 4*s/(s + 200)
       else 1
 
     ###


### PR DESCRIPTION
Make the critical hit bonus diminish towards +450%, so the maximum multiplier is 550%. A step towards fixing https://github.com/HabitRPG/habitrpg/issues/4148 . (I haven't actually tested this on my own HabitRPG setup yet; my internet is not cooperating with all the node modules.)

A table for comparing how this helps with exploding stats, especially STR:

```
  stat   old mult new mult
     1    1.52000  1.51990
    25    2.00000  1.94444
    50    2.50000  2.30000
    75    3.00000  2.59091
   100    3.50000  2.83333
   150    4.50000  3.21429
   200    5.50000  3.50000
   250    6.50000  3.72222
   300    7.50000  3.90000
   400    9.50000  4.16667
   600   13.50000  4.50000
  1000   21.50000  4.83333
 10000  201.50000  5.42157
100000 2001.50000  5.49202
```
