### PR TITLE
make Gold=>Gem conversion cap message more accurate in terms of when to wait until - fixes https://github.com/HabitRPG/habitrpg/issues/3996

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -697,7 +697,7 @@ api.wrap = (user, main=true) ->
           {convRate,convCap} = api.planGemLimits
           return cb?({code:401,message:"Must subscribe to purchase gems with GP"},req) unless user.purchased?.plan?.planId
           return cb?({code:401,message:"Not enough Gold"}) unless user.stats.gp >= convRate
-          return cb?({code:401,message:"You've reached the Gold=>Gem conversion cap (#{convCap}) for this month. We have this to prevent abuse / farming, please wait until the beginning of next month."}) if user.purchased.plan.gemsBought >= convCap
+          return cb?({code:401,message:"You've reached the Gold=>Gem conversion cap (#{convCap}) for this month. We have this to prevent abuse / farming. The cap will reset within the first three days of next month."}) if user.purchased.plan.gemsBought >= convCap
           user.balance += .25
           user.purchased.plan.gemsBought++
           user.stats.gp -= convRate


### PR DESCRIPTION
Currrently, when a subscriber buys 25 gems with gold in a month, they get this message:
"_You've reached the Gold=>Gem conversion cap (25) for this month. We have this to prevent abuse / farming, please wait until the beginning of next month._"

This PR changes it to this (bold indicates the changed words):
"You've reached the Gold=>Gem conversion cap (25) for this month. We have this to prevent abuse / farming. **_The cap will reset within the first three days of next month.**_"
### Reason for change:

People in timezones ahead of the USA reach the beginning of the month several hours before the start of the process to reset the cap. I believe that process takes several more hours to run. Thus some people don't have the cap lifted until the 2nd or maybe 3rd of the month in their timezones.

There's usually questions about this at the start of every month. Changing the message would prevent most of the questions, thus freeing up our time for other kinds of support work.
