### PR TITLE
Prettify Market Gem

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -40,3 +40,8 @@
 [class*="Mount_Head_"], [class*="Mount_Body_"]{
   margin-top:18px; /* Sprite accommodates 105x123 box */
 }
+
+.Pet_Currency_Gem {
+  margin-top: 5px;
+  margin-bottom: 5px
+}

--- a/css/index.css
+++ b/css/index.css
@@ -45,8 +45,3 @@
   margin-top: 5px;
   margin-bottom: 5px
 }
-
-.pet_key {
-  margin-top: 5px;
-  margin-bottom: 5px
-}

--- a/css/index.css
+++ b/css/index.css
@@ -45,3 +45,8 @@
   margin-top: 5px;
   margin-bottom: 5px
 }
+
+.pet_key {
+  margin-top: 5px;
+  margin-bottom: 5px
+}

--- a/locales/en/subscriber.json
+++ b/locales/en/subscriber.json
@@ -60,5 +60,7 @@
     "checkout": "Checkout",
     "buySubsText": "Buy gems with Gold, No Ads, Support the Devs",
     "sureCancelSub": "Are you sure you want to cancel your subscription?",
-    "subCanceled": "Subscription will become inactive on"
+    "subCanceled": "Subscription will become inactive on",
+    "subGemPop": "Because you subscribe to HabitRPG, you can purchase a number of Gems each month using Gold. You can see how many Gems are available to buy at the corner of the Gem icon.",
+    "subGemName": "Subscriber Gems"
 }


### PR DESCRIPTION
Adds a margin to the purchasable Gem in the Market so it doesn't look so wonky compared to other market items.

Before:
![image](https://cloud.githubusercontent.com/assets/4501321/5293662/be3c8416-7b3b-11e4-8b1b-27be4329bf34.png)

After:
![image](https://cloud.githubusercontent.com/assets/4501321/5293668/d7547e72-7b3b-11e4-83e1-96faf477bebb.png)

I couldn't find anywhere else this particular zoom level of the Gem icon was used, but keep an eye out!
