### PR TITLE
MP gain revisions

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -15471,7 +15471,7 @@ api.wrap = function(user, main) {
         return typeof cb === "function" ? cb(null, user.items.gear.owned) : void 0;
       },
       score: function(req, cb) {
-        var addPoints, calculateDelta, calculateReverseDelta, changeTaskValue, delta, direction, id, mpDelta, multiplier, num, options, stats, subtractPoints, task, th, _ref;
+        var addPoints, calculateDelta, calculateReverseDelta, changeTaskValue, delta, direction, gainMP, id, multiplier, num, options, stats, subtractPoints, task, th, _ref;
         _ref = req.params, id = _ref.id, direction = _ref.direction;
         task = user.tasks[id];
         options = req.query || {};
@@ -15582,9 +15582,20 @@ api.wrap = function(user, main) {
           hpMod = delta * conBonus * task.priority * 2;
           return stats.hp += Math.round(hpMod * 10) / 10;
         };
+        gainMP = function(delta) {
+          delta *= user._tmp.crit || 1;
+          user.stats.mp += delta;
+          if (user.stats.mp >= user._statsComputed.maxMP) {
+            user.stats.mp = user._statsComputed.maxMP;
+          }
+          if (user.stats.mp < 0) {
+            return user.stats.mp = 0;
+          }
+        };
         switch (task.type) {
           case 'habit':
             changeTaskValue();
+            gainMP(_.max([0.25, .0025 * user._statsComputed.maxMP]) * (direction === 'down' ? -1 : 1));
             if (delta > 0) {
               addPoints();
             } else {
@@ -15614,6 +15625,7 @@ api.wrap = function(user, main) {
               }
             } else {
               changeTaskValue();
+              gainMP(_.max([1, .01 * user._statsComputed.maxMP]) * (direction === 'down' ? -1 : 1));
               if (direction === 'down') {
                 delta = calculateDelta();
               }
@@ -15646,18 +15658,7 @@ api.wrap = function(user, main) {
                   return m + (i.completed ? 1 : 0);
                 }), 1), 1
               ]);
-              mpDelta = _.max([multiplier, .01 * user._statsComputed.maxMP * multiplier]);
-              mpDelta *= user._tmp.crit || 1;
-              if (direction === 'down') {
-                mpDelta *= -1;
-              }
-              user.stats.mp += mpDelta;
-              if (user.stats.mp >= user._statsComputed.maxMP) {
-                user.stats.mp = user._statsComputed.maxMP;
-              }
-              if (user.stats.mp < 0) {
-                user.stats.mp = 0;
-              }
+              gainMP(_.max([multiplier, .01 * user._statsComputed.maxMP * multiplier]) * (direction === 'down' ? -1 : 1));
             }
             break;
           case 'reward':
@@ -15733,14 +15734,16 @@ api.wrap = function(user, main) {
       return x - Math.floor(x);
     },
     crit: function(stat, chance) {
+      var s;
       if (stat == null) {
         stat = 'str';
       }
       if (chance == null) {
         chance = .03;
       }
-      if (user.fns.predictableRandom() <= chance * (1 + user._statsComputed[stat] / 100)) {
-        return 1.5 + (.02 * user._statsComputed[stat]);
+      s = user._statsComputed[stat];
+      if (user.fns.predictableRandom() <= chance * (1 + s / 100)) {
+        return 1.5 + 4 * s / (s + 200);
       } else {
         return 1;
       }
@@ -16256,5 +16259,5 @@ api.wrap = function(user, main) {
 };
 
 
-}).call(this,require("/Users/lefnire/Google Drive/Sync/Sites/habitrpg/modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js"))
-},{"./content.coffee":5,"./i18n.coffee":6,"/Users/lefnire/Google Drive/Sync/Sites/habitrpg/modules/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js":2,"lodash":3,"moment":4}]},{},[1])
+}).call(this,require("/home/sabrecat/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js"))
+},{"./content.coffee":5,"./i18n.coffee":6,"/home/sabrecat/habitrpg-shared/node_modules/browserify/node_modules/insert-module-globals/node_modules/process/browser.js":2,"lodash":3,"moment":4}]},{},[1])

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1049,6 +1049,12 @@ api.wrap = (user, main=true) ->
           hpMod = delta * conBonus * task.priority * 2 # constant 2 multiplier for better results
           stats.hp += Math.round(hpMod * 10) / 10 # round to 1dp
 
+        gainMP = (delta) ->
+          delta *= user._tmp.crit or 1
+          user.stats.mp += delta
+          user.stats.mp = user._statsComputed.maxMP if user.stats.mp >= user._statsComputed.maxMP
+          user.stats.mp = 0 if user.stats.mp < 0
+
         switch task.type
           when 'habit'
             changeTaskValue()
@@ -1182,12 +1188,6 @@ api.wrap = (user, main=true) ->
     # ----------------------------------------------------------------------
     # Scoring
     # ----------------------------------------------------------------------
-
-    gainMP: (delta) ->
-      delta *= user._tmp.crit or 1
-      user.stats.mp += delta
-      user.stats.mp = user._statsComputed.maxMP if user.stats.mp >= user._statsComputed.maxMP
-      user.stats.mp = 0 if user.stats.mp < 0
 
     randomDrop: (modifiers, req) ->
       {task} = modifiers

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1052,6 +1052,7 @@ api.wrap = (user, main=true) ->
         switch task.type
           when 'habit'
             changeTaskValue()
+            gainMP(_.max([0.25, (.0025 * user._statsComputed.maxMP)]) * if direction is 'down' then -1 else 1)
             # Add habit value to habit-history (if different)
             if (delta > 0) then addPoints() else subtractPoints()
 
@@ -1070,6 +1071,7 @@ api.wrap = (user, main=true) ->
               task.streak = 0 unless user.stats.buffs.streaks
             else
               changeTaskValue()
+              gainMP(_.max([1, (.01 * user._statsComputed.maxMP)]) * if direction is 'down' then -1 else 1)
               if direction is 'down'
                 delta = calculateDelta() # recalculate delta for unchecking so the gp and exp come out correctly
               addPoints() # obviously for delta>0, but also a trick to undo accidental checkboxes
@@ -1096,12 +1098,7 @@ api.wrap = (user, main=true) ->
               addPoints() # obviously for delta>0, but also a trick to undo accidental checkboxes
               # MP++ per checklist item in ToDo, bonus per CLI
               multiplier = _.max([(_.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),1)),1])
-              mpDelta = _.max([(multiplier), (.01 * user._statsComputed.maxMP * multiplier)])
-              mpDelta *= user._tmp.crit or 1
-              mpDelta *= -1 if direction is 'down'  # unticking a todo
-              user.stats.mp += mpDelta
-              user.stats.mp = user._statsComputed.maxMP if user.stats.mp >= user._statsComputed.maxMP
-              user.stats.mp = 0 if user.stats.mp < 0   # BUT DO WE WANT THIS? SEE COMMIT DESCRIPTION
+              gainMP(_.max([(multiplier), (.01 * user._statsComputed.maxMP * multiplier)]) * if direction is 'down' then -1 else 1)
 
           when 'reward'
           # Don't adjust values for rewards
@@ -1185,6 +1182,12 @@ api.wrap = (user, main=true) ->
     # ----------------------------------------------------------------------
     # Scoring
     # ----------------------------------------------------------------------
+
+    gainMP: (delta) ->
+      delta *= user._tmp.crit or 1
+      user.stats.mp += delta
+      user.stats.mp = user._statsComputed.maxMP if user.stats.mp >= user._statsComputed.maxMP
+      user.stats.mp = 0 if user.stats.mp < 0
 
     randomDrop: (modifiers, req) ->
       {task} = modifiers


### PR DESCRIPTION
1. Dailies give MP at baseline rate, unaffected by checklists.
2. Habits affect MP at 25% of baseline. You can lose MP by indulging in bad Habits!
3. To-Dos continue to give MP at baseline with a bonus multiplier from checklist items completed.

"Baseline" is the greater of 1 or 1/10 of the player's max MP.

Also includes some minor refactoring, moving some reused code for gaining MP from tasks into a `gainMP` function within `score`.

Addresses a couple of the checkpoints in https://github.com/HabitRPG/habitrpg/issues/3029.
