### PR TITLE
Implement boss damage from Habits

### DIFF
--- a/dist/habitrpg-shared.js
+++ b/dist/habitrpg-shared.js
@@ -15550,10 +15550,13 @@ api.wrap = function(user, main) {
               if (user.preferences.automaticAllocation === true && user.preferences.allocationMode === 'taskbased' && !(task.type === 'todo' && direction === 'down')) {
                 user.stats.training[task.attribute] += nextDelta;
               }
-              if (direction === 'up' && !(task.type === 'habit' && !task.down)) {
+              if (direction === 'up') {
                 user.party.quest.progress.up = user.party.quest.progress.up || 0;
                 if ((_ref1 = task.type) === 'daily' || _ref1 === 'todo') {
                   user.party.quest.progress.up += nextDelta * (1 + (user._statsComputed.str / 200));
+                }
+                if (task.type === 'habit') {
+                  user.party.quest.progress.up += nextDelta * (0.5 + (user._statsComputed.str / 400));
                 }
               }
               task.value += nextDelta;

--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1003,12 +1003,10 @@ api.wrap = (user, main=true) ->
             nextDelta = if not options.cron and direction is 'down' then calculateReverseDelta() else calculateDelta()
             unless task.type is 'reward'
               if (user.preferences.automaticAllocation is true and user.preferences.allocationMode is 'taskbased' and !(task.type is 'todo' and direction is 'down')) then user.stats.training[task.attribute] += nextDelta
-              # ===== STRENGTH =====
-              # (Only for up-scoring, ignore up-onlies and rewards)
-              # Note, we create a new val (adjustAmt) to add to task.value, since delta will be used in Exp & GP calculations - we don't want STR to bonus that
-              if direction is 'up' and !(task.type is 'habit' and !task.down)
+              if direction is 'up' # Make progress on quest based on STR
                 user.party.quest.progress.up = user.party.quest.progress.up || 0;
                 user.party.quest.progress.up += (nextDelta * (1 + (user._statsComputed.str / 200))) if task.type in ['daily','todo']
+                user.party.quest.progress.up += (nextDelta * (0.5 + (user._statsComputed.str / 400))) if task.type is 'habit'
               task.value += nextDelta
             delta += nextDelta
 


### PR DESCRIPTION
- Habit hits now damage bosses at half the strength of Dailies and To-Dos. Also removed a bit of leftover commentary/logic from back when STR caused tasks to get blue faster.

Addresses one of the "Task Changes" checkpoints from https://github.com/HabitRPG/habitrpg/issues/3029 .
