### PR TITLE
Streamlined "Confers no benefit" placements

### DIFF
--- a/locales/en/gear.json
+++ b/locales/en/gear.json
@@ -180,7 +180,7 @@
   "armorSpecialBirthdayNotes": "As part of the festivities, Absurd Party Robes are available free of charge in the Item Store! Swath yourself in those silly garbs and don your matching hats to celebrate this momentous day. Confers no benefit.",
 
   "armorSpecialGaymerxText": "Rainbow Warrior Armor",
-  "armorSpecialGaymerxNotes": "(Confers no benefit) In celebration of pride season and GaymerX, this special armor is decorated with a radiant, colorful rainbow pattern! GaymerX is a game convention celebrating LGBTQ and gaming and is open to everyone. It takes place at the InterContinental in downtown San Francisco on July 11-13!",
+  "armorSpecialGaymerxNotes": "In celebration of pride season and GaymerX, this special armor is decorated with a radiant, colorful rainbow pattern! GaymerX is a game convention celebrating LGBTQ and gaming and is open to everyone. It takes place at the InterContinental in downtown San Francisco on July 11-13! Confers no benefit.",
 
   "armorSpecialSpringRogueText": "Sleek Cat Suit",
   "armorSpecialSpringRogueNotes": "Impeccably groomed. Increases Perception by <%= per %>. Limited Edition 2014 Spring Gear.",
@@ -226,7 +226,7 @@
   "armorMystery201410Text": "Goblin Gear",
   "armorMystery201410Notes": "Scaly, slimy, and strong! Confers no benefit. October 2014 Subscriber Item.",
   "armorMystery301404Text": "Steampunk Suit",
-  "armorMystery301404Notes": "Dapper and dashing, wot! February 3015 Subscriber Item. Confers no benefit.",
+  "armorMystery301404Notes": "Dapper and dashing, wot! Confers no benefit. February 3015 Subscriber Item.",
 
   "headBase0Text": "No Helm",
   "headBase0Notes": "No headgear.",
@@ -321,7 +321,7 @@
   "headSpecialFallHealerNotes": "Highly sanitary and very fashionable. Increases Intelligence by <%= int %>. Limited Edition 2014 Autumn Gear.",
 
   "headSpecialGaymerxText": "Rainbow Warrior Helm",
-  "headSpecialGaymerxNotes": "(Confers no benefit) In celebration of pride season and GaymerX, this special helmet is decorated with a radiant, colorful rainbow pattern! GaymerX is a game convention celebrating LGBTQ and gaming and is open to everyone. It takes place at the InterContinental in downtown San Francisco on July 11-13!",
+  "headSpecialGaymerxNotes": "In celebration of pride season and GaymerX, this special helmet is decorated with a radiant, colorful rainbow pattern! GaymerX is a game convention celebrating LGBTQ and gaming and is open to everyone. It takes place at the InterContinental in downtown San Francisco on July 11-13! Confers no benefit.",
 
   "headMystery201402Text": "Winged Helm",
   "headMystery201402Notes": "This winged circlet imbues the wearer with the speed of the wind! Confers no benefit. February 2014 Subscriber Item.",
@@ -338,7 +338,7 @@
   "headMystery301404Text": "Fancy Top Hat",
   "headMystery301404Notes": "A fancy top hat for the finest of gentlefolk! January 3015 Subscriber Item. Confers no benefit.",
   "headMystery301405Text": "Basic Top Hat",
-  "headMystery301405Notes": "A basic top hat, just begging to be paired with some fancy head accessories. May 3015 Subscriber Item. Confers no benefit.",
+  "headMystery301405Notes": "A basic top hat, just begging to be paired with some fancy head accessories. Confers no benefit. May 3015 Subscriber Item.",
 
   "shieldBase0Text": "No Off-Hand Equipment",
   "shieldBase0Notes": "No shield or second weapon.",
@@ -400,7 +400,7 @@
   "shieldSpecialFallHealerNotes": "This glittery shield was found in an ancient tomb. Increases Constitution by <%= con %>. Limited Edition 2014 Autumn Gear.",
 
   "shieldMystery301405Text": "Clock Shield",
-  "shieldMystery301405Notes": "Time is on your side with this towering clock shield! June 3015 Subscriber Item. Confers no benefit.",
+  "shieldMystery301405Notes": "Time is on your side with this towering clock shield! Confers no benefit. June 3015 Subscriber Item.",
 
   "backBase0Text": "No Back Accessory",
   "backBase0Notes": "No Back Accessory.",
@@ -452,7 +452,7 @@
   "headAccessoryMystery201409Text": "Autumn Antlers",
   "headAccessoryMystery201409Notes": "These powerful antlers change colors with the leaves. Confers no benefit. September 2014 Subscriber Item.",
   "headAccessoryMystery301405Text": "Headwear Goggles",
-  "headAccessoryMystery301405Notes": "\"Goggles are for your eyes,\" they said. \"Nobody wants goggles that you can only wear on your head,\" they said. Hah! You sure showed them! August 3015 Subscriber Item. Confers no benefit.",
+  "headAccessoryMystery301405Notes": "\"Goggles are for your eyes,\" they said. \"Nobody wants goggles that you can only wear on your head,\" they said. Hah! You sure showed them! Confers no benefit. August 3015 Subscriber Item.",
 
   "eyewearBase0Text": "No Eyewear",
   "eyewearBase0Notes": "No Eyewear.",
@@ -468,7 +468,7 @@
   "eyewearSpecialWonderconBlackNotes": "Your motives are definitely legitimate. Confers no benefit. Special Edition Convention Item.",
 
   "eyewearMystery301404Text": "Eyewear Goggles",
-  "eyewearMystery301404Notes": "No eyewear could be fancier than a pair of goggles - except, perhaps, for a monocle. April 3015 Subscriber Item. Confers no benefit.",
+  "eyewearMystery301404Notes": "No eyewear could be fancier than a pair of goggles - except, perhaps, for a monocle. Confers no benefit. April 3015 Subscriber Item.",
   "eyewearMystery301405Text": "Monocle",
-  "eyewearMystery301405Notes": "No eyewear could be fancier than a monocle - except, perhaps, for a pair of goggles. July 3015 Subscriber Item. Confers no benefit."
+  "eyewearMystery301405Notes": "No eyewear could be fancier than a monocle - except, perhaps, for a pair of goggles. Confers no benefit. July 3015 Subscriber Item."
 }


### PR DESCRIPTION
Streamlined the placement of "Confers no benefit" so it doesn't change location between similar sentences.
