### PR TITLE
Added phantomjssmith to solve `Fatal error: Unsupported interlace method`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "0.0.0",
   "dependencies": {
     "browserify": "~3.30.2",
-    "coffeeify": "0.6.0",
     "coffee-script": "1.7.1",
-    "moment": "~2.8.3",
+    "coffeeify": "0.6.0",
+    "grunt-spritesmith": "~1.22.0",
     "lodash": "~2.4.1",
-    "grunt-spritesmith": "~1.22.0"
+    "moment": "~2.8.3",
+    "phantomjssmith": "^0.5.4"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Was getting `Fatal error: Unsupported interlace method` whenever I would run `grunt sprite`.

I was able to solve this by first running `npm install -g phantomjs`, then `npm install phantomjssmith --save`.

Devs who are compiling the sprites. Does that make sense to you? Should I add a line to the README about it?
