### PR TITLE
Style Guide for Equipment Descriptions

### DIFF
--- a/locales/en/gear_README.md
+++ b/locales/en/gear_README.md
@@ -8,16 +8,16 @@ To maintain consistency in equipment descriptions, the following guidelines have
 3. Event/Origin (if needed)
 
 #### Stat Effect
-* *No bonus:*
+* **No bonus:**
 "Confers no benefit."
-* *Single or all stat bonus:*
+* **Single or all stat bonus:**
 "Increases (Strength/Intelligence/Constitution/Perception/all attributes) by (<%= str %>/<%= int %>/<%= con %>/<%= per %>/<%= attrs %>)."
-* *Two stats, same bonus:*
+* **Two stats, same bonus:**
 "Increases (Strength/Intelligence/Constitution) and (Intelligence/Constitution/Perception) by <%= attrs %> each."
-* *Two stats, different bonus:*
+* **Two stats, different bonus:**
 "Increases (Strength/Intelligence/Constitution) by (<%= str %>/<%= int %>/<%= con %>) and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)]."
 
 #### Event/Origin:
 Examples of wording:
-* "(Month) (Year) Subscriber Item." _E.g., "November 2014 Subscriber Item."_
-* Limited Edition (Year) (Season) Gear. _E.g., "Limited Edition 2014 Spring Gear."_
+* "[Month] [Year] Subscriber Item." (_e.g., "November 2014 Subscriber Item."_)
+* "Limited Edition [Year] [Season] Gear." (_e.g., "Limited Edition 2014 Spring Gear."_)

--- a/locales/en/gear_README.md
+++ b/locales/en/gear_README.md
@@ -1,20 +1,21 @@
+# Style Guide for Equipment Descriptions
+
 To maintain consistency in equipment descriptions, the following guidelines have been proposed (https://github.com/HabitRPG/habitrpg-shared/pull/372):
 
-#### Order of elements:
-1. Description.
-2. Stat Effect.
-3. Event/Origin(if needed)
+#### Order of elements
+1. Description
+2. Stat Effect
+3. Event/Origin (if needed)
 
 #### Stat Effect
-Examples of wording:
 * No bonus:
-* Confers no benefit.
+"Confers no benefit."
 * Single or all stat bonus:
-* Increases (Strength/Intelligence/Constitution/Perception/all attributes) by (<%= str %>/<%= int %>/<%= con %>/<%= per %>/<%= attrs %>).
+"Increases (Strength/Intelligence/Constitution/Perception/all attributes) by (<%= str %>/<%= int %>/<%= con %>/<%= per %>/<%= attrs %>)."
 * Two stats, same bonus:
-* Increases (Strength/Intelligence/Constitution) and (Intelligence/Constitution/Perception) by <%= attrs %> each.
-* Two stats, different bonus
-* Increases (Strength/Intelligence/Constitution) by (<%= str %>/<%= int %>/<%= con %>) and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)].
+"Increases (Strength/Intelligence/Constitution) and (Intelligence/Constitution/Perception) by <%= attrs %> each."
+* Two stats, different bonus:
+"Increases (Strength/Intelligence/Constitution) by (<%= str %>/<%= int %>/<%= con %>) and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)]."
 
 Long form:
 * Confers no benefit. / Increases (Strength/Intelligence/Constitution/Perception/all attributes) [and (Intelligence/Constitution/Perception)] by (<%= str %>/<%= int %>/<%= con %>/<%= per %>/<%= attrs %>) [each/and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)].

--- a/locales/en/gear_README.md
+++ b/locales/en/gear_README.md
@@ -8,19 +8,16 @@ To maintain consistency in equipment descriptions, the following guidelines have
 3. Event/Origin (if needed)
 
 #### Stat Effect
-* No bonus:
+* *No bonus:*
 "Confers no benefit."
-* Single or all stat bonus:
+* *Single or all stat bonus:*
 "Increases (Strength/Intelligence/Constitution/Perception/all attributes) by (<%= str %>/<%= int %>/<%= con %>/<%= per %>/<%= attrs %>)."
-* Two stats, same bonus:
+* *Two stats, same bonus:*
 "Increases (Strength/Intelligence/Constitution) and (Intelligence/Constitution/Perception) by <%= attrs %> each."
-* Two stats, different bonus:
+* *Two stats, different bonus:*
 "Increases (Strength/Intelligence/Constitution) by (<%= str %>/<%= int %>/<%= con %>) and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)]."
-
-Long form:
-* Confers no benefit. / Increases (Strength/Intelligence/Constitution/Perception/all attributes) [and (Intelligence/Constitution/Perception)] by (<%= str %>/<%= int %>/<%= con %>/<%= per %>/<%= attrs %>) [each/and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)].
 
 #### Event/Origin:
 Examples of wording:
-* (Month) (Year) Subscriber Item.
-* Limited Edition (Year) (Season) Gear.
+* "(Month) (Year) Subscriber Item." _E.g., "November 2014 Subscriber Item."_
+* Limited Edition (Year) (Season) Gear. _E.g., "Limited Edition 2014 Spring Gear."_

--- a/locales/en/gear_README.md
+++ b/locales/en/gear_README.md
@@ -1,0 +1,25 @@
+To maintain consistency in equipment descriptions, the following guidelines have been proposed (https://github.com/HabitRPG/habitrpg-shared/pull/372):
+
+#### Order of elements:
+1. Description.
+2. Stat Effect.
+3. Event/Origin(if needed)
+
+#### Stat Effect
+Examples of wording:
+* No bonus:
+* Confers no benefit.
+* Single or all stat bonus:
+* Increases (Strength/Intelligence/Constitution/Perception/all attributes) by (<%= str %>/<%= int %>/<%= con %>/<%= per %>/<%= attrs %>).
+* Two stats, same bonus:
+* Increases (Strength/Intelligence/Constitution) and (Intelligence/Constitution/Perception) by <%= attrs %> each.
+* Two stats, different bonus
+* Increases (Strength/Intelligence/Constitution) by (<%= str %>/<%= int %>/<%= con %>) and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)].
+
+Long form:
+* Confers no benefit. / Increases (Strength/Intelligence/Constitution/Perception/all attributes) [and (Intelligence/Constitution/Perception)] by (<%= str %>/<%= int %>/<%= con %>/<%= per %>/<%= attrs %>) [each/and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)].
+
+#### Event/Origin:
+Examples of wording:
+* (Month) (Year) Subscriber Item.
+* Limited Edition (Year) (Season) Gear.

--- a/locales/en/gear_README.md
+++ b/locales/en/gear_README.md
@@ -2,12 +2,12 @@
 
 To maintain consistency in equipment descriptions, the following guidelines have been proposed (https://github.com/HabitRPG/habitrpg-shared/pull/372):
 
-#### Order of elements
+## Order of elements
 1. Description
 2. Stat Effect
 3. Event/Origin (if needed)
 
-#### Stat Effect
+## Stat Effect
 * **No bonus:**
 "Confers no benefit."
 * **Single or all stat bonus:**
@@ -17,7 +17,7 @@ To maintain consistency in equipment descriptions, the following guidelines have
 * **Two stats, different bonus:**
 "Increases (Strength/Intelligence/Constitution) by (<%= str %>/<%= int %>/<%= con %>) and (Intelligence/Constitution/Perception) by (<%= int %>/<%= con %>/<%= per %>)]."
 
-#### Event/Origin:
+## Event/Origin
 Examples of wording:
 * "[Month] [Year] Subscriber Item." (_e.g., "November 2014 Subscriber Item."_)
 * "Limited Edition [Year] [Season] Gear." (_e.g., "Limited Edition 2014 Spring Gear."_)


### PR DESCRIPTION
@ShilohT proposed some guidelines for consistency in equipment descriptions (https://github.com/HabitRPG/habitrpg-shared/pull/372). This PR puts them into a README file in the same directory as gear.json.

[This is what the file will look like when viewed normally.](https://github.com/Alys/habitrpg-shared/blob/d34b1167327c41d1142518e199af6613e56e671d/locales/en/gear_README.md)

ping @SabreCat @lemoness
