### PR TITLE
Fix tests

### DIFF
--- a/test/algos.mocha.coffee
+++ b/test/algos.mocha.coffee
@@ -320,7 +320,8 @@ describe 'User', ->
         expect(quest.value).to.be.greaterThan 0 if quest.canBuy
         expect(quest.drop.gp).to.not.be.lessThan 0
         expect(quest.drop.exp).to.not.be.lessThan 0
-        expect(quest.drop.items).to.be.an(Array)
+        if quest.drop.items
+          expect(quest.drop.items).to.be.an(Object)
         if quest.boss
           expect(quest.boss.name()).to.be.an('string')
           expect(quest.boss.hp).to.be.greaterThan 0

--- a/test/algos.mocha.coffee
+++ b/test/algos.mocha.coffee
@@ -185,7 +185,7 @@ describe 'User', ->
     user = undefined
     it 'revives correctly', ->
       user = newUser()
-      user.stats = { gp: 10, exp: 100, lvl: 2, hp: 1 }
+      user.stats = { gp: 10, exp: 100, lvl: 2, hp: 0 }
       user.ops.revive()
       expect(user).toHaveGP 0
       expect(user).toHaveExp 0

--- a/test/algos.mocha.coffee
+++ b/test/algos.mocha.coffee
@@ -202,10 +202,13 @@ describe 'User', ->
       user.items.gear.owned['shield_rogue_1'] = true
       user.items.gear.owned['head_special_nye'] = true
       expect(ce user.items.gear.owned).to.be 4
+      user.stats.hp = 0
       user.ops.revive()
       expect(ce(user.items.gear.owned)).to.be 3
+      user.stats.hp = 0
       user.ops.revive()
       expect(ce(user.items.gear.owned)).to.be 2
+      user.stats.hp = 0
       user.ops.revive()
       expect(ce(user.items.gear.owned)).to.be 2
       expect(user.items.gear.owned).to.eql { weapon_warrior_0: false, shield_warrior_1: false, shield_rogue_1: true, head_special_nye: true }

--- a/test/algos.mocha.coffee
+++ b/test/algos.mocha.coffee
@@ -324,7 +324,7 @@ describe 'User', ->
         expect(quest.drop.gp).to.not.be.lessThan 0
         expect(quest.drop.exp).to.not.be.lessThan 0
         if quest.drop.items
-          expect(quest.drop.items).to.be.an(Object)
+          expect(quest.drop.items).to.be.an(Array)
         if quest.boss
           expect(quest.boss.name()).to.be.an('string')
           expect(quest.boss.hp).to.be.greaterThan 0


### PR DESCRIPTION
Corrected some failing tests.

Mostly the [user.ops.revive function requires that the user has 0 hp](https://github.com/HabitRPG/habitrpg-shared/blob/5e168c41cecc4626e9fd1914c4dffd86eb4d640c/script/index.coffee#L402) to work.

The other failing test expected for `quest.drop.items` to be an array, but the Basi list quest doesn't have an items property, so I just had it check to make sure `quest.drop.items` exists first.

Could not figure out [this one though](https://github.com/HabitRPG/habitrpg-shared/blob/develop/test/algos.mocha.coffee#L194). It's still failing inexplicably.
