### PR TITLE
Updated spritesmith

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,8 +23,9 @@ module.exports = function(grunt) {
     var sliced = images.slice(i * (images.length/COUNT), (i+1) * images.length/COUNT)
     sprite[''+i] = {
       src: sliced,
-      destImg: 'dist/spritesmith'+i+'.png',
-      destCSS: 'dist/spritesmith'+i+'.css',
+      dest: 'dist/spritesmith'+i+'.png',
+      destCss: 'dist/spritesmith'+i+'.css',
+      engine: 'phantomjssmith',
       algorithm: 'binary-tree',
       padding:1,
       cssTemplate: 'css/css.template.mustache',

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "0.0.0",
   "dependencies": {
     "browserify": "~3.30.2",
-    "coffeeify": "0.6.0",
     "coffee-script": "1.7.1",
-    "moment": "~2.8.3",
+    "coffeeify": "0.6.0",
+    "grunt-spritesmith": "~3.5.0",
     "lodash": "~2.4.1",
-    "grunt-spritesmith": "~1.22.0"
+    "moment": "~2.8.3",
+    "phantomjssmith": "~0.5.4"
   },
   "devDependencies": {
     "coffee-coverage": "~0.4.2",


### PR DESCRIPTION
Updated spritesmith the the latest version, adjusted the gruntfile to accommodate the breaking changes that v3 brought in, and specified the engine as phantomjssmith.

Now all the weird interlace and phantomjs crashing errors I was getting on `grunt sprite` are fixed.
