### PR TITLE
add remove-watch and use-timeout attribute to the markdown directive

### DIFF
--- a/script/directives.js
+++ b/script/directives.js
@@ -92,7 +92,7 @@
         var removeWatch = !!scope.$eval(attrs.removeWatch);
         var useTimeout = !!scope.$eval(attrs.useTimeout);
 
-        var doRemoveWatch = scope.$watch(attrs.ngModel, function(value, oldValue) {
+        var doRemoveWatch = scope.$watch(attrs.text, function(value, oldValue) {
           var replaceMarkdown = function(){
 
             var markdown = value;

--- a/script/directives.js
+++ b/script/directives.js
@@ -85,26 +85,46 @@
     };
   }();
 
-  habitrpg.directive('markdown', function() {
+  habitrpg.directive('markdown', ['$timeout', function($timeout) {
     return {
       restrict: 'E',
       link: function(scope, element, attrs) {
-        scope.$watch(attrs.ngModel, function(value, oldValue) {
-          var markdown = value;
-          var linktarget = attrs.target || '_self';
-          var userName = scope.User.user.profile.name;
-          var userHighlight = "@"+userName;
-          var html = md.toHtml(markdown);
-          
-          html = html.replace(userHighlight, "<u>@"+userName+"</u>");
-          
-          html = html.replace(' href',' target="'+linktarget+'" href');
-          element.html(html);
+        var removeWatch = !!scope.$eval(attrs.removeWatch);
+        var useTimeout = !!scope.$eval(attrs.useTimeout);
+
+        var doRemoveWatch = scope.$watch(attrs.ngModel, function(value, oldValue) {
+          var replaceMarkdown = function(){
+
+            var markdown = value;
+            var linktarget = attrs.target || '_self';
+            var userName = scope.User.user.profile.name;
+            var userHighlight = "@"+userName;
+            var html = md.toHtml(markdown);
+
+            html = html.replace(userHighlight, "<u>@"+userName+"</u>");
+
+            html = html.replace(' href',' target="'+linktarget+'" href');
+            element.html(html);
+
+            if(removeWatch)
+            {
+              doRemoveWatch(); 
+            }
+          };
+
+          if(useTimeout)
+          {
+            $timeout(replaceMarkdown, 0);
+          }
+          else
+          {
+            replaceMarkdown();
+          }
         });
       }
     };
-  });
-  
+  }]);
+
   habitrpg.filter('markdown', function() {
     return function(input){
       var html = md.toHtml(input);


### PR DESCRIPTION
Many angular watches are of the markdown directive, i've added two attributes which could improve step-by-step the performance.

For example if we use-timeout, we could delay the markdown parsing for some ms, and not start every markdown parsing instantly.

Also not every markdown needs to watch for changes, here comes the remove-watch attribute to help, for example this could be used on the chat messages 

Ping @paglias @crookedneighbor @lefnire  Any other ideas on this directive which I should implement? If not I'll merge this in 1-2 days :)
