### PR TITLE
off-hand to shield-hand in gear.json and questsContent.json

### DIFF
--- a/locales/en/gear.json
+++ b/locales/en/gear.json
@@ -379,9 +379,9 @@
   "headMystery301405Text": "Basic Top Hat",
   "headMystery301405Notes": "A basic top hat, just begging to be paired with some fancy head accessories. Confers no benefit. May 3015 Subscriber Item.",
 
-  "offhand": "off-hand item",
+  "offhand": "shield-hand item",
 
-  "shieldBase0Text": "No Off-Hand Equipment",
+  "shieldBase0Text": "No Shield-Hand Equipment",
   "shieldBase0Notes": "No shield or second weapon.",
 
   "shieldWarrior1Text": "Wooden Shield",

--- a/locales/en/questsContent.json
+++ b/locales/en/questsContent.json
@@ -111,7 +111,7 @@
   "questGoldenknight3Boss": "The Iron Knight",
   "questGoldenknight3DropHoney": "Honey (Food)",
   "questGoldenknight3DropGoldenPotion": "Golden Hatching Potion",
-  "questGoldenknight3DropWeapon": "Mustaine's Milestone Mashing Morning Star (Off-hand Weapon)",
+  "questGoldenknight3DropWeapon": "Mustaine's Milestone Mashing Morning Star (Shield-hand Weapon)",
 
   "questBasilistText": "The Basi-List",
   "questBasilistNotes": "There's a commotion in the marketplace--the kind that should make you run away. Being a courageous adventurer, you run towards it instead, and discover a Basi-list, coalescing from a clump of incomplete To-Dos! Nearby Habiticans are paralyzed with fear at the length of the Basi-list, unable to start working. From somewhere in the vicinity, you hear @Arcosine shout: \"Quick! Complete your To-Dos and Dailies to defang the monster, before someone gets a paper cut!\" Strike fast, adventurer, and check something off - but beware! If you leave any Dailies undone, the Basi-list will attack you and your party!",


### PR DESCRIPTION
I haven't confirmed this works on the site because I'm still trying to figure out how to add weapons - db.users.update({_id: 'bec4aa9c-0be1-4131-aa47-a1bc40d4a910''}, {$set: {"items.gear.owned":"questGoldenknight3DropWeapon": true}} didn't seem to work, I probably need to add the weapon before I set it to true? But I figured this was a simple enough fix that I'd submit it for now and figure out the testing tomorrow/later this week.
