### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/HabitRPG/habitrpg-shared.png?branch=master)](https://travis-ci.org/HabitRPG/habitrpg-shared)
 
-## We're in the process of migraring this repository to the main HabitRPG repository, you can report any issue [here](https://github.com/HabitRPG/habitrpg).
+## We're in the process of migrating this repository to the main HabitRPG repository, you can report any issue [here](https://github.com/HabitRPG/habitrpg).
 Shared resources useful for the multiple HabitRPG repositories, that way all the repositories remain in-sync with common characteristics. Includes things like:
  * Assets - sprites, images, etc
  * CSS - especially, esp. sprite-sheet mapping


### PR DESCRIPTION
in the banner about migrating this repo migrating was typo'd as migraring.

:purple_heart: 
