### PR TITLE
Adjust calculation of cronMP from checklists

### DIFF
--- a/script/index.coffee
+++ b/script/index.coffee
@@ -1489,8 +1489,8 @@ api.wrap = (user, main=true) ->
 
         # Deduct experience for missed Daily tasks, but not for Todos (just increase todo's value)
         if completed
-          if (type is 'daily')
-            dailyChecked++
+          if type is 'daily'
+            dailyChecked += 1
         else
           scheduleMisses = daysMissed
           # for dailys which have repeat dates, need to calculate how many they've missed according to their own schedule
@@ -1503,7 +1503,9 @@ api.wrap = (user, main=true) ->
             if type is 'daily'
               perfect = false 
               if task.checklist?.length > 0  # Partially completed checklists dock fewer mana points
-                dailyDueUnchecked += (1 - _.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),0) / task.checklist.length)
+                fractionChecked = _.reduce(task.checklist,((m,i)->m+(if i.completed then 1 else 0)),0) / task.checklist.length
+                dailyDueUnchecked += (1 - fractionChecked)
+                dailyChecked += fractionChecked
               else
                dailyDueUnchecked += 1
             delta = user.ops.score({params:{id:task.id, direction:'down'}, query:{times:scheduleMisses, cron:true}});


### PR DESCRIPTION
Tests performed:

*no dailies, 1 unchecked todo, 4 checked todos: +10 MP, DueUnchecked=0, Checked=1

*2 dailies with checklists, one with 3 items, one with 4 items (1 unchecked todo, 4 checked todos)
    Check nothing off: 0 MP, DueUncheck=2, Checked = 0
    Check off 1/3 checklist only:  +1.66... MP, DueUnchecked=1.66..., Checked = 0.33...
    Check off 2/3 checklist only: +3.33... MP, DueUnchecked = 1.333..., Checked = 0.66...
    Check off 3/3 checklist only: +5 MP, DueUnchecked = 1, Checked= 1
    Check off 1 main and associated 3/3 checklist: +5 MP, DueUnchecked =1, Checked=1
    Check off 1 main and not checklist: +5 MP, DueUnchecked=1, Checked=1
    Check off main for 3/3 checklist and 1/4 checklist: +6.25 MP, DueUnchecked=0.75 Unchecked, Checked=1.25.
    Check off main for 3/3 checklist and 2/4 checklist: +7.5 MP, Dueunchecked=0.5, Checked=1.5
    Check off main for 3/3 checklist and 3/4 checklist: +8.75 MP, DueUnchecked=0.25, Checked=1.75
